### PR TITLE
[Translate] Don't send translate msg if bot add react

### DIFF
--- a/translate/translate.py
+++ b/translate/translate.py
@@ -197,6 +197,8 @@ class Translate(getattr(commands, "Cog", object)):
             user = guild.get_member(payload.user_id)
         except:
             return
+        if user.bot:
+            return
         if await self.config.api_key() is None:
             return
         # check_emoji = lambda emoji: emoji in FLAGS


### PR DESCRIPTION
Hello, I've removed the possibility of send translate messages if a bot react with a flag emoji. It's a thing that was reported to me and I think it can be useful so that's why I suggest it to you.