### PR TITLE
[ExtendedModLog] Make emoji changes show when right setting is enabled

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -937,7 +937,7 @@ class EventMixin:
 
     @listener()
     async def on_guild_emojis_update(self, guild, before, after):
-        if not await self.config.guild(guild).guild_change.enabled():
+        if not await self.config.guild(guild).emoji_change.enabled():
             return
         try:
             channel = await self.modlog_channel(guild, "emoji_change")


### PR DESCRIPTION
Use `emoji_change` setting instead of `guild_change`.

Sorry for doing all these small fixes in separate PRs, but I just notice them randomly while looking through code 👀 And I guess it's better to put it in separate PRs if they're not changes about one thing ¯\_(ツ)_/¯