### PR TITLE
[Translate] DM channels don't have .guild attr

### DIFF
--- a/translate/api.py
+++ b/translate/api.py
@@ -214,7 +214,7 @@ class GoogleTranslateAPI:
         if payload.message_id in self.cache["translations"]:
             return
         channel = self.bot.get_channel(id=payload.channel_id)
-        if not channel.guild:
+        if channel.recipient:
             return
         guild = channel.guild
         user = guild.get_member(payload.user_id)


### PR DESCRIPTION
Fixes the following traceback in Translate when a reaction is added in a DM channel.
```
Ignoring exception in raw_reaction_add
Traceback (most recent call last):
  File "/root/.local/share/catv3/lib/python3.7/site-packages/discord/client.py", line 255, in _run_event
    await coro(*args, **kwargs)
  File "/root/.local/share/Red-DiscordBot/cogs/CogManager/cogs/translate/api.py", line 217, in on_raw_reaction_add
    if not channel.guild:
AttributeError: 'DMChannel' object has no attribute 'guild'
```
