### PR TITLE
[ExtendedModLog] Use `Message.clean_content` to get text without mentions

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -108,7 +108,6 @@ class EventMixin:
         except RuntimeError:
             return
         time = ctx.message.created_at
-        cleanmsg = ctx.message.content
         message = ctx.message
         can_run = await self.member_can_run(ctx)
         command = ctx.message.content.replace(ctx.prefix, "")
@@ -140,8 +139,6 @@ class EventMixin:
         else:
             role = f"everyone\n{privs}"
 
-        for i in ctx.message.mentions:
-            cleanmsg = cleanmsg.replace(i.mention, str(i))
         infomessage = (
             f"{message.author.name}#{message.author.discriminator}"
             + _(" used ")
@@ -154,7 +151,7 @@ class EventMixin:
 
             embed = discord.Embed(
                 title=infomessage,
-                description=cleanmsg,
+                description=message.content,
                 colour=await self.get_colour(guild),
                 timestamp=time,
             )
@@ -166,8 +163,8 @@ class EventMixin:
             embed.set_author(name=author_title, icon_url=message.author.avatar_url)
             await channel.send(embed=embed)
         else:
-            clean_msg = f"{infomessage}\n`{cleanmsg}`"
-            await channel.send(clean_msg)
+            clean_msg = f"{infomessage}\n`{message.clean_content}`"
+            await channel.send(clean_msg[:2000])
 
     @listener()
     async def on_message_delete(self, message):
@@ -189,9 +186,6 @@ class EventMixin:
         if message.content == "" and message.attachments == []:
             return
         time = message.created_at
-        cleanmsg = message.content
-        for i in message.mentions:
-            cleanmsg = cleanmsg.replace(i.mention, str(i))
         perp = None
         if channel.permissions_for(guild.me).view_audit_log:
             action = discord.AuditLogAction.message_delete
@@ -226,7 +220,8 @@ class EventMixin:
             )
             await channel.send(embed=embed)
         else:
-            await channel.send(infomessage)
+            clean_msg = f"{infomessage}\n`{message.clean_content}`"
+            await channel.send(clean_msg[:2000])
 
     async def invite_links_loop(self):
         """Check every 5 minutes for updates to the invite links"""
@@ -836,12 +831,6 @@ class EventMixin:
             return
         if before.content == after.content:
             return
-        cleanbefore = before.content
-        for i in before.mentions:
-            cleanbefore = cleanbefore.replace(i.mention, str(i))
-        cleanafter = after.content
-        for i in after.mentions:
-            cleanafter = cleanafter.replace(i.mention, str(i))
         try:
             channel = await self.modlog_channel(guild, "message_edit")
         except RuntimeError:
@@ -871,9 +860,9 @@ class EventMixin:
                 + f"**{before.channel.mention}"
                 + f" **{before.author.name}#{before.author.discriminator}'s** "
                 + _("message has been edited.\nBefore: ")
-                + cleanbefore
+                + before.clean_content
                 + _("\nAfter: ")
-                + cleanafter
+                + after.clean_content
             )
             await channel.send(msg[:2000])
 


### PR DESCRIPTION
Instead of just iterating through `Message.mentions`, because that's not enough as it still leaves role and everyone/here mentions. I decided to just go with solution that discord.py gives - `Message.clean_content`
I also decided to make sure that modlog message is under 2000 characters when embeds can't be used.