### PR TITLE
[ExtendedModLog] Setting for bulk message delete notifications

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -13,8 +13,10 @@ from redbot.core.i18n import Translator, cog_i18n
 _ = Translator("ExtendedModLog", __file__)
 logger = logging.getLogger("red.trusty-cogs.ExtendedModLog")
 listener = getattr(commands.Cog, "listener", None)  # red 3.0 backwards compatibility support
+below_red31 = False
 
 if listener is None:  # thanks Sinbad
+    below_red31 = True
     def listener(name=None):
         return lambda x: x
 
@@ -261,7 +263,7 @@ class EventMixin:
                 + _("messages deleted.")
             )
             await channel.send(infomessage)
-        if settings["bulk_individual"]:
+        if not below_red31 and settings["bulk_individual"]:
             for message in payload.cached_messages:
                 try:
                     await self.on_message_delete(message, check_audit_log=False)

--- a/extendedmodlog/extendedmodlog.py
+++ b/extendedmodlog/extendedmodlog.py
@@ -385,6 +385,9 @@ class ExtendedModLog(EventMixin, commands.Cog):
     async def _delete_bulk_individual(self, ctx):
         """
             Toggle individual message delete notifications for bulk message delete
+
+            NOTE: In versions under Red 3.1 this setting doesn't work
+            and individual message delete notifications will show regardless of it.
         """
         guild = ctx.message.guild
         msg = _("Individual message delete logs for bulk message delete ")

--- a/extendedmodlog/extendedmodlog.py
+++ b/extendedmodlog/extendedmodlog.py
@@ -8,7 +8,13 @@ from .eventmixin import EventMixin, CommandPrivs
 
 inv_settings = {
     "message_edit": {"enabled": False, "channel": None, "bots": False},
-    "message_delete": {"enabled": False, "channel": None, "bots": False},
+    "message_delete": {
+        "enabled": False,
+        "channel": None,
+        "bots": False,
+        "bulk_enabled": False,
+        "bulk_individual": False
+    },
     "user_change": {"enabled": False, "channel": None},
     "role_change": {"enabled": False, "channel": None},
     "voice_change": {"enabled": False, "channel": None},
@@ -350,6 +356,43 @@ class ExtendedModLog(EventMixin, commands.Cog):
             verb = _("enabled")
         else:
             await self.config.guild(guild).message_delete.bots.set(False)
+            verb = _("disabled")
+        await ctx.send(msg + verb)
+
+    @_delete.group(name="bulk")
+    async def _delete_bulk(self, ctx):
+        """
+            Bulk message delete logging settings
+        """
+        pass
+
+    @_delete_bulk.command(name="toggle")
+    async def _delete_bulk_toggle(self, ctx):
+        """
+            Toggle bulk message delete notifications
+        """
+        guild = ctx.message.guild
+        msg = _("Bulk message delete logs ")
+        if not await self.config.guild(guild).message_delete.bulk_enabled():
+            await self.config.guild(guild).message_delete.bulk_enabled.set(True)
+            verb = _("enabled")
+        else:
+            await self.config.guild(guild).message_delete.bulk_enabled.set(False)
+            verb = _("disabled")
+        await ctx.send(msg + verb)
+
+    @_delete_bulk.command(name="individual")
+    async def _delete_bulk_individual(self, ctx):
+        """
+            Toggle individual message delete notifications for bulk message delete
+        """
+        guild = ctx.message.guild
+        msg = _("Individual message delete logs for bulk message delete ")
+        if not await self.config.guild(guild).message_delete.bulk_individual():
+            await self.config.guild(guild).message_delete.bulk_individual.set(True)
+            verb = _("enabled")
+        else:
+            await self.config.guild(guild).message_delete.bulk_individual.set(False)
             verb = _("disabled")
         await ctx.send(msg + verb)
 


### PR DESCRIPTION
This adds support for bulk message deletes. You'll be able to use `[p]modlog delete bulk toggle` to enable bulk message delete notifications and `[p]modlog delete bulk individual` to enable message delete notifications for individual messages in bulk delete event.

This was done in backwards compatible manner, but the individual messages in bulk delete event can't be disabled under Red 3.1, because d.py from those versions automatically dispatched `message_delete` events for bulk delete events.

If you will merge PR #49 first, I need to apply additional changes before this PR will be ready for merge. Feel free to ping me on Discord (Jackenmen#6607) in main Red server or cog support one, if you merge one of those PRs.