### PR TITLE
[ExtendedModLog] Option to send cached images in delete notifications

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -260,7 +260,7 @@ class EventMixin:
             if message.attachments:
                 filenames = ", ".join(a.filename for a in message.attachments)
                 embed.add_field(name=_("Attachments"), value=filenames)
-                if settings["send_cached_images"]:
+                if settings["send_cached_images"] and not below_red31:
                     size = 0
                     manage_webhooks = channel.permissions_for(guild.me).manage_webhooks
                     for a in message.attachments:

--- a/extendedmodlog/extendedmodlog.py
+++ b/extendedmodlog/extendedmodlog.py
@@ -436,6 +436,7 @@ class ExtendedModLog(EventMixin, commands.Cog):
             If attachments size exceeds 8MB (discord's size limit)
             bot will try to send attachments that fit this limit.
 
+            NOTE: This setting only works in Red 3.1+
             WARNING: This will delay message delete notifications for messages
             with big attachments.
         """

--- a/extendedmodlog/extendedmodlog.py
+++ b/extendedmodlog/extendedmodlog.py
@@ -15,6 +15,7 @@ inv_settings = {
         "bulk_enabled": False,
         "bulk_individual": False,
         "cached_only": True,
+        "send_cached_images": False,
     },
     "user_change": {"enabled": False, "channel": None},
     "role_change": {"enabled": False, "channel": None},
@@ -419,6 +420,26 @@ class ExtendedModLog(EventMixin, commands.Cog):
         else:
             await self.config.guild(guild).message_delete.cached_only.set(False)
             verb = _("enabled")
+        await ctx.send(msg + verb)
+
+    @_delete.command(name="sendcachedimages")
+    async def _delete_sendcachedimages(self, ctx):
+        """
+            Toggle sending cached images in message delete notifications.
+
+            If attachments size exceeds 8MB bot will try to
+            send attachments that fit this limit.
+            NOTE: There is no guarantee that image was cached by discord,
+            so don't rely on this.
+        """
+        guild = ctx.message.guild
+        msg = _("Sending cached images ")
+        if not await self.config.guild(guild).message_delete.send_cached_images():
+            await self.config.guild(guild).message_delete.send_cached_images.set(True)
+            verb = _("enabled")
+        else:
+            await self.config.guild(guild).message_delete.send_cached_images.set(False)
+            verb = _("disabled")
         await ctx.send(msg + verb)
 
     @_delete.command(name="channel")

--- a/extendedmodlog/extendedmodlog.py
+++ b/extendedmodlog/extendedmodlog.py
@@ -427,10 +427,17 @@ class ExtendedModLog(EventMixin, commands.Cog):
         """
             Toggle sending cached images in message delete notifications.
 
-            If attachments size exceeds 8MB bot will try to
-            send attachments that fit this limit.
-            NOTE: There is no guarantee that image was cached by discord,
-            so don't rely on this.
+            Keep in mind there is no guarantee that image will stay in cache,
+            so sometimes delete notification may be sent without attached images.
+
+            If bot doesn't have Manage Webhooks permissions in modlog channel,
+            it will only send one image.
+
+            If attachments size exceeds 8MB (discord's size limit)
+            bot will try to send attachments that fit this limit.
+
+            WARNING: This will delay message delete notifications for messages
+            with big attachments.
         """
         guild = ctx.message.guild
         msg = _("Sending cached images ")


### PR DESCRIPTION
This will allow user to enable sending cached images in delete notifications.

While the feature itself is tested, you may want to know how this looks, so here are screenshots of delete notification for message with one attachment and message with three attachments.
![Discord_2019-07-18_04-48-49](https://user-images.githubusercontent.com/6032823/61425481-611ad080-a917-11e9-8ec8-46d5e7a4d798.png)
![Discord_2019-07-18_04-49-00](https://user-images.githubusercontent.com/6032823/61425482-611ad080-a917-11e9-861f-764c89f0c4a0.png)

Some people may think multiple attachments take too much space, but messages with multiple attachments are pretty rare and this can be disabled by denying bot Manage Webhooks permission (see below).

When message contains more than 1 attachment, bot will only send first one unless it has Manage Webhooks permission that allows it to use webhook and send multiple embeds (screenshots above present that).

Feature only works on Red 3.1+, though if you really want, I *could* make it support versions under that (it's not supported natively by d.py and I would have to either use aiohttp or maybe some hidden method in d.py's http client), I just don't think it makes much sense to give new features to old Red version as there shouldn't be anything stopping people to just update it.