### PR TITLE
[Extendedmodlog] Fixes for 3.1 changes

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -366,7 +366,10 @@ class EventMixin:
             if not possible_link:
                 for code, data in invites.items():
                     try:
-                        invite = await self.bot.get_invite(code)
+                        try:
+                            invite = await self.bot.get_invite(code)
+                        except AttributeError:
+                            invite = await self.bot.fetch_invite(code)
                     except (discord.errors.NotFound, discord.errors.HTTPException, Exception):
                         logger.error("Error getting invite ".format(code))
                         invite = None
@@ -375,7 +378,10 @@ class EventMixin:
                         if (data["max_uses"] - data["uses"]) == 1:
                             # The invite link was on its last uses and subsequently
                             # deleted so we're fairly sure this was the one used
-                            inviter = await self.bot.get_user_info(data["inviter"])
+                            try:
+                                inviter = await self.bot.get_user_info(data["inviter"])
+                            except AttributeError:
+                                inviter = await self.bot.fetch_user(data["inviter"])
                             possible_link = _(
                                 "https://discord.gg/{code}\n" "Invited by: {inviter}"
                             ).format(code=code, inviter=str(inviter))


### PR DESCRIPTION
Added compatability for `get_invite` which converts to `fetch_invite` in 3.1, and `get_user_info` which converts to `fetch_user` to stop the console being spammed with "Error getting invite".