### PR TITLE
[ServerStats] Fix an UnboundLocalError on whois command in old Red versions

### DIFF
--- a/serverstats/serverstats.py
+++ b/serverstats/serverstats.py
@@ -752,7 +752,7 @@ class ServerStats(commands.Cog):
             try:
                 member = await self.bot.fetch_user(user_id)
             except AttributeError:
-                member = await self.bot.get_user_info(member)
+                member = await self.bot.get_user_info(user_id)
             except discord.errors.NotFound:
                 await ctx.send(str(user_id) + _(" doesn't seem to be a discord user."))
                 return


### PR DESCRIPTION
This PR just fix a wrong var in whois command which was doing an error on old Red versions.