### PR TITLE
[Tweets] Escape discord markdown in tweet's content

### DIFF
--- a/tweets/tweets.py
+++ b/tweets/tweets.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from io import BytesIO
 from redbot.core import Config, checks, commands
-from redbot.core.utils.chat_formatting import pagify
+from redbot.core.utils.chat_formatting import escape, pagify
 from redbot.core.i18n import Translator, cog_i18n
 from .tweet_entry import TweetEntry
 import tweepy as tw
@@ -236,7 +236,7 @@ class Tweets(commands.Cog):
             except IndexError:
                 log.debug(_("Error grabbing in reply to tweet."), exc_info=True)
 
-        em.description = text.replace("&amp;", "\n\n")
+        em.description = escape(text.replace("&amp;", "\n\n"), formatting=True)
 
         return em
 


### PR DESCRIPTION
Twitter doesn't have it's markdown while discord does and content of tweet may look different on Twitter and on Discord due to that. I used escape function from Red's utilities to fix this.

Example tweet that is getting affected by this (https://twitter.com/LUCIFERwriters/status/1182389469833355264):
![chrome_2019-10-10_23-36-44](https://user-images.githubusercontent.com/6032823/66608603-3909d900-ebb7-11e9-86d0-2b46b34d113c.png)

After fix:
![image](https://user-images.githubusercontent.com/6032823/66608568-2099be80-ebb7-11e9-8253-d5a8518364f8.png)