### PR TITLE
[NotSoBot] Add missing async

### DIFF
--- a/notsobot/notsobot.py
+++ b/notsobot/notsobot.py
@@ -259,7 +259,7 @@ class NotSoBot(commands.Cog):
             "lang": "python",
             "expire": "0",
         }
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession() as session:
             async with session.post("https://spit.mixtape.moe/api/create", data=payload) as r:
                 url = await r.text()
                 await ctx.send("Uploaded to paste, URL: <{0}>".format(url))


### PR DESCRIPTION
Fixes an error when commands call the gist function:

```
Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "/root/.local/share/Red-DiscordBot/cogs/CogManager/cogs/notsobot/notsobot.py", line 683, in ascii
    await self.gist(ctx, text, txt)
  File "/root/.local/share/Red-DiscordBot/cogs/CogManager/cogs/notsobot/notsobot.py", line 262, in gist
    with aiohttp.ClientSession() as session:
  File "/.../lib/python3.7/site-packages/aiohttp/client.py", line 956, in __enter__
    raise TypeError("Use async with instead")
TypeError: Use async with instead

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../lib/python3.7/site-packages/discord/ext/commands/bot.py", line 863, in invoke
    await ctx.command.invoke(ctx)
  File "/.../lib/python3.7/site-packages/discord/ext/commands/core.py", line 728, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/.../lib/python3.7/site-packages/discord/ext/commands/core.py", line 88, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: Use async with instead
```