### PR TITLE
[Serverstats] Fix botstats in dms

### DIFF
--- a/serverstats/serverstats.py
+++ b/serverstats/serverstats.py
@@ -344,10 +344,16 @@ class ServerStats(commands.Cog):
         em = discord.Embed(
             description=msg, colour=await ctx.embed_colour(), timestamp=ctx.message.created_at
         )
-        em.set_author(
-            name=f"{ctx.me} {f'~ {ctx.me.nick}' if ctx.me.nick else ''}",
-            icon_url=ctx.me.avatar_url,
-        )
+        if ctx.guild:
+            em.set_author(
+                name=f"{ctx.me} {f'~ {ctx.me.nick}' if ctx.me.nick else ''}",
+                icon_url=ctx.me.avatar_url,
+            )
+        else:
+            em.set_author(
+                name=f"{ctx.me}",
+                icon_url=ctx.me.avatar_url,
+            )
         em.set_thumbnail(url=ctx.me.avatar_url)
         if ctx.channel.permissions_for(ctx.me).embed_links:
             await ctx.send(embed=em)


### PR DESCRIPTION
Resolves a traceback when botstats is used in dms.

```
Exception in command 'botstats'
Traceback (most recent call last):
  File "/.../catv3/lib/python3.7/site-packages/discord/ext/commands/core.py", line 79, in wrapped
    ret = await coro(*args, **kwargs)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/serverstats/serverstats.py", line 348, in botstats
    name=f"{ctx.me} {f'~ {ctx.me.nick}' if ctx.me.nick else ''}",
AttributeError: 'ClientUser' object has no attribute 'nick'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../catv3/lib/python3.7/site-packages/discord/ext/commands/bot.py", line 863, in invoke
    await ctx.command.invoke(ctx)
  File "/.../catv3/lib/python3.7/site-packages/discord/ext/commands/core.py", line 728, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/.../catv3/lib/python3.7/site-packages/discord/ext/commands/core.py", line 88, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'ClientUser' object has no attribute 'nick'
```