### PR TITLE
Correctly default the singular bot message.

### DIFF
--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -25,7 +25,7 @@ default_settings = {
     "GOODBYE": [default_goodbye],
     "CHANNEL": None,
     "WHISPER": False,
-    "BOTS_MSG": [default_bot_msg],
+    "BOTS_MSG": default_bot_msg,
     "BOTS_ROLE": None,
     "EMBED": False,
     "JOINED_TODAY": False,


### PR DESCRIPTION
Default the bot message to str instead of a list which is not supported. Fixes https://github.com/TrustyJAID/Trusty-cogs/issues/107