### PR TITLE
[AdventureAlert] Fix the version number of the sanitize_roles change

### DIFF
--- a/adventurealert/adventurealert.py
+++ b/adventurealert/adventurealert.py
@@ -10,7 +10,7 @@ from .bossalert import BossAlert
 from .minibossalert import MinibossAlert
 from .cartalert import CartAlert
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}


### PR DESCRIPTION
Hi,
this is a follow up to #106, it turned out that 3.3.2 release will in fact be 3.4.0 release as people in Red decided that this change should be considered breaking after all.
This shouldn't really matter cause the check you have there already works for anything past 3.2.2 and that includes 3.4.0, but it might clearer for people looking at this code in the future.