### PR TITLE
[Welcome] Different Embed Images for Greetings and Goodbyes

### DIFF
--- a/welcome/events.py
+++ b/welcome/events.py
@@ -104,8 +104,8 @@ class Events:
             elif url == "avatar" and isinstance(member, discord.Member):
                 url = member.avatar_url
             em.set_thumbnail(url=url)
-        if (is_welcome and EMBED_DATA["image_greeting"]) or (not is_welcome and EMBED_DATA["image_goodbye"]):
-            url = EMBED_DATA["image_greeting"] if is_welcome else EMBED_DATA["image_goodbye"]
+        if (is_welcome and EMBED_DATA["image"]) or (not is_welcome and EMBED_DATA["image_goodbye"]):
+            url = EMBED_DATA["image"] if is_welcome else EMBED_DATA["image_goodbye"]
             if url == "guild":
                 url = guild.icon_url
             elif url == "splash":

--- a/welcome/events.py
+++ b/welcome/events.py
@@ -104,8 +104,8 @@ class Events:
             elif url == "avatar" and isinstance(member, discord.Member):
                 url = member.avatar_url
             em.set_thumbnail(url=url)
-        if EMBED_DATA["image"]:
-            url = EMBED_DATA["image"]
+        if (is_welcome and EMBED_DATA["image_greeting"]) or (not is_welcome and EMBED_DATA["image_goodbye"]):
+            url = EMBED_DATA["image_greeting"] if is_welcome else EMBED_DATA["image_goodbye"]
             if url == "guild":
                 url = guild.icon_url
             elif url == "splash":

--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -40,7 +40,7 @@ default_settings = {
         "colour": 0,
         "footer": None,
         "thumbnail": None,
-        "image_greeting": None,
+        "image": None,
         "image_goodbye": None,
         "icon_url": None,
         "author": True,
@@ -683,7 +683,7 @@ class Welcome(Events, commands.Cog):
     @_image.command(name="greeting")
     async def image_greeting(self, ctx: commands.Context, link: Optional[str] = None) -> None:
         """
-        Set the embed image link
+        Set the embed image link for greetings
 
         `[link]` must be a valid image link
         You may also specify:
@@ -695,16 +695,16 @@ class Welcome(Events, commands.Cog):
         if link is not None:
             link_search = IMAGE_LINKS.search(link)
             if link_search:
-                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set(link_search.group(0))
+                await self.config.guild(ctx.guild).EMBED_DATA.image.set(link_search.group(0))
                 await ctx.tick()
             elif link in ["author", "avatar"]:
-                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("avatar")
+                await self.config.guild(ctx.guild).EMBED_DATA.image.set("avatar")
                 await ctx.tick()
             elif link in ["server", "guild"]:
-                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("guild")
+                await self.config.guild(ctx.guild).EMBED_DATA.image.set("guild")
                 await ctx.tick()
             elif link == "splash":
-                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("splash")
+                await self.config.guild(ctx.guild).EMBED_DATA.image.set("splash")
                 await ctx.tick()
             else:
                 await ctx.send(
@@ -712,12 +712,12 @@ class Welcome(Events, commands.Cog):
                 )
         else:
             await self.config.guild(ctx.guild).EMBED_DATA.image.set(None)
-            await ctx.send(_("Image cleared."))
+            await ctx.send(_("Greeting image cleared."))
 
     @_image.command(name="goodbye")
     async def image_goodbye(self, ctx: commands.Context, link: Optional[str] = None) -> None:
         """
-        Set the embed image link
+        Set the embed image link for goodbyes
 
         `[link]` must be a valid image link
         You may also specify:
@@ -746,7 +746,7 @@ class Welcome(Events, commands.Cog):
                 )
         else:
             await self.config.guild(ctx.guild).EMBED_DATA.image.set(None)
-            await ctx.send(_("Image cleared."))
+            await ctx.send(_("Goodbye image cleared."))
 
     @_embed.command()
     async def timestamp(self, ctx: commands.Context) -> None:

--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -40,7 +40,8 @@ default_settings = {
         "colour": 0,
         "footer": None,
         "thumbnail": None,
-        "image": None,
+        "image_greeting": None,
+        "image_goodbye": None,
         "icon_url": None,
         "author": True,
         "timestamp": True,
@@ -672,8 +673,15 @@ class Welcome(Events, commands.Cog):
             await self.config.guild(ctx.guild).EMBED_DATA.icon_url.set(None)
             await ctx.send(_("Icon cleared."))
 
-    @_embed.command()
-    async def image(self, ctx: commands.Context, link: Optional[str] = None) -> None:
+    @_embed.group(name="image")
+    async def _image(self, ctx: commands.Context) -> None:
+        """
+        Set embed image options
+        """
+        pass
+
+    @_image.command(name="greeting")
+    async def image_greeting(self, ctx: commands.Context, link: Optional[str] = None) -> None:
         """
         Set the embed image link
 
@@ -687,16 +695,50 @@ class Welcome(Events, commands.Cog):
         if link is not None:
             link_search = IMAGE_LINKS.search(link)
             if link_search:
-                await self.config.guild(ctx.guild).EMBED_DATA.image.set(link_search.group(0))
+                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set(link_search.group(0))
                 await ctx.tick()
             elif link in ["author", "avatar"]:
-                await self.config.guild(ctx.guild).EMBED_DATA.image.set("avatar")
+                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("avatar")
                 await ctx.tick()
             elif link in ["server", "guild"]:
-                await self.config.guild(ctx.guild).EMBED_DATA.image.set("guild")
+                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("guild")
                 await ctx.tick()
             elif link == "splash":
-                await self.config.guild(ctx.guild).EMBED_DATA.image.set("splash")
+                await self.config.guild(ctx.guild).EMBED_DATA.image_greeting.set("splash")
+                await ctx.tick()
+            else:
+                await ctx.send(
+                    _("That's not a valid option. You must provide a link, `avatar` or `server`.")
+                )
+        else:
+            await self.config.guild(ctx.guild).EMBED_DATA.image.set(None)
+            await ctx.send(_("Image cleared."))
+
+    @_image.command(name="goodbye")
+    async def image_goodbye(self, ctx: commands.Context, link: Optional[str] = None) -> None:
+        """
+        Set the embed image link
+
+        `[link]` must be a valid image link
+        You may also specify:
+         `member`, `user` or `avatar` to use the members avatar
+        `server` or `guild` to use the servers icon
+        `splash` to use the servers splash image if available
+        if nothing is provided the defaults are used.
+        """
+        if link is not None:
+            link_search = IMAGE_LINKS.search(link)
+            if link_search:
+                await self.config.guild(ctx.guild).EMBED_DATA.image_goodbye.set(link_search.group(0))
+                await ctx.tick()
+            elif link in ["author", "avatar"]:
+                await self.config.guild(ctx.guild).EMBED_DATA.image_goodbye.set("avatar")
+                await ctx.tick()
+            elif link in ["server", "guild"]:
+                await self.config.guild(ctx.guild).EMBED_DATA.image_goodbye.set("guild")
+                await ctx.tick()
+            elif link == "splash":
+                await self.config.guild(ctx.guild).EMBED_DATA.image_goodbye.set("splash")
                 await ctx.tick()
             else:
                 await ctx.send(

--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -745,7 +745,7 @@ class Welcome(Events, commands.Cog):
                     _("That's not a valid option. You must provide a link, `avatar` or `server`.")
                 )
         else:
-            await self.config.guild(ctx.guild).EMBED_DATA.image.set(None)
+            await self.config.guild(ctx.guild).EMBED_DATA.image_goodbye.set(None)
             await ctx.send(_("Goodbye image cleared."))
 
     @_embed.command()


### PR DESCRIPTION
First and foremost, thank you for rewriting this for V3. 

There is some rework that can be made for this cog cleaner, but the one thing I really wanted was the support for different images for the embed messages. So the quickest way to have this available was to simply add another key inside of EMBED_DATA, then just handle which image to use when creating the embed.


**SETTING UP**
<img src="https://imgur.com/wFv5gNK.gif">

**TEST**
<img src="https://imgur.com/xMrO1SP.gif">