### PR TITLE
[Starboard] Fix _check_roles when User object

### DIFF
--- a/starboard/events.py
+++ b/starboard/events.py
@@ -1,7 +1,7 @@
 import discord
 import logging
 
-from typing import List, cast, Dict
+from typing import List, cast, Dict, Union
 
 from redbot.core.bot import Red
 from redbot.core import Config, commands
@@ -63,10 +63,14 @@ class StarboardEvents:
         text_msg += _("{msg} Starboard {name}\n").format(msg=msg, name=starboard.name)
         return (embed, text_msg)
 
-    async def _check_roles(self, starboard: StarboardEntry, member: discord.Member) -> bool:
+    async def _check_roles(
+        self, starboard: StarboardEntry, member: Union[discord.Member, discord.User]
+    ) -> bool:
         """Checks if the user is allowed to add to the starboard
            Allows bot owner to always add messages for testing
            disallows users from adding their own messages"""
+        if isinstance(member, discord.User):
+            return True
         user_roles = set([role.id for role in member.roles])
         if starboard.whitelist_role:
             for role in starboard.whitelist_role:
@@ -83,7 +87,9 @@ class StarboardEvents:
 
         return True
 
-    async def _check_channel(self, starboard: StarboardEntry, channel: discord.TextChannel) -> bool:
+    async def _check_channel(
+        self, starboard: StarboardEntry, channel: discord.TextChannel
+    ) -> bool:
         """CHecks if the channel is allowed to track starboard
         messages"""
         if starboard.whitelist_channel:


### PR DESCRIPTION
This fix that error. It is also happenning with `on_raw_reaction_add`.
That error was making starboard messages not updating.
```py
Ignoring exception in on_raw_reaction_add
Traceback (most recent call last):
  File "/venv/lib/python3.8/site-packages/discord/client.py", line 311, in _run_event
    await coro(*args, **kwargs)
  File "/cogs/CogManager/cogs/starboard/events.py", line 189, in on_raw_reaction_add
    await self._update_stars(payload)
  File "/cogs/CogManager/cogs/starboard/events.py", line 256, in _update_stars
    if await self._loop_messages(payload, starboard, star_channel, msg):
  File "/cogs/CogManager/cogs/starboard/events.py", line 304, in _loop_messages
    count = await self._get_count(messages, starboard)
  File "/cogs/CogManager/cogs/starboard/events.py", line 169, in _get_count
    if not await self._check_roles(starboard, user):
  File "/cogs/CogManager/cogs/starboard/events.py", line 70, in _check_roles
    user_roles = set([role.id for role in member.roles])
AttributeError: 'User' object has no attribute 'roles'
```