### PR TITLE
[AdventureAlert] No DMs for adventurealert add

### DIFF
--- a/adventurealert/adventurealert.py
+++ b/adventurealert/adventurealert.py
@@ -150,6 +150,7 @@ class AdventureAlert(
                 _("{role} will now receive notifications on adventures.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @adventurealert.command(name="add", aliases=["user", "users", "remove", "rem", "toggle"])
     async def adventure_users(self, ctx: commands.Context) -> None:
         """Toggle adventure notifications in this server"""

--- a/adventurealert/ascendedalert.py
+++ b/adventurealert/ascendedalert.py
@@ -34,6 +34,7 @@ class AscendedAlert(MixinMeta):
                 _("{role} will now receive notifications on ascendeds.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @ascendedalert.command(name="add", aliases=["user", "users", "remove", "rem"])
     async def ascended_users(self, ctx: commands.Context) -> None:
         """Toggle ascended notifications on this server"""

--- a/adventurealert/bossalert.py
+++ b/adventurealert/bossalert.py
@@ -34,6 +34,7 @@ class BossAlert(MixinMeta):
                 _("{role} will now receive notifications on dragons.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @dragonalert.command(name="add", aliases=["user", "users", "remove", "rem"])
     async def boss_users(self, ctx: commands.Context) -> None:
         """Toggle dragon notifications on this server"""

--- a/adventurealert/cartalert.py
+++ b/adventurealert/cartalert.py
@@ -34,6 +34,7 @@ class CartAlert(MixinMeta):
                 _("{role} will now receive notifications on carts.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @cartalert.command(name="add", aliases=["user", "users", "remove", "rem", "toggle"])
     async def cart_users(self, ctx: commands.Context) -> None:
         """Toggle cart notifications on this server"""

--- a/adventurealert/immortalalert.py
+++ b/adventurealert/immortalalert.py
@@ -34,6 +34,7 @@ class ImmortalAlert(MixinMeta):
                 _("{role} will now receive notifications on immortals.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @immortalalert.command(name="add", aliases=["user", "users", "remove", "rem"])
     async def immortal_users(self, ctx: commands.Context) -> None:
         """Toggle immortal notifications on this server"""

--- a/adventurealert/minibossalert.py
+++ b/adventurealert/minibossalert.py
@@ -38,6 +38,7 @@ class MinibossAlert(MixinMeta):
                 )
             )
 
+    @commands.guild_only()
     @minibossalert.command(name="add", aliases=["user", "users", "remove", "rem", "toggle"])
     async def miniboss_users(self, ctx: commands.Context) -> None:
         """Toggle miniboss notifications in this server"""

--- a/adventurealert/possessedalert.py
+++ b/adventurealert/possessedalert.py
@@ -34,6 +34,7 @@ class PossessedAlert(MixinMeta):
                 _("{role} will now receive notifications on possesseds.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @possessedalert.command(name="add", aliases=["user", "users", "remove", "rem"])
     async def possessed_users(self, ctx: commands.Context) -> None:
         """Toggle possessed notifications on this server"""

--- a/adventurealert/transcendedalert.py
+++ b/adventurealert/transcendedalert.py
@@ -34,6 +34,7 @@ class TranscendedAlert(MixinMeta):
                 _("{role} will now receive notifications on transcendeds.").format(role=role.name)
             )
 
+    @commands.guild_only()
     @transcendedalert.command(name="add", aliases=["user", "users", "remove", "rem"])
     async def transcended_users(self, ctx: commands.Context) -> None:
         """Toggle transcended notifications on this server"""


### PR DESCRIPTION
Just adding a guild_only deco.

Using adventurealert add in DMs will lead to a traceback as it's expecting to find a guild config.

```
[2020-06-30 16:23:40] [ERROR] red: Exception in command 'adventurealert add'
Traceback (most recent call last):
  File "/.../cat38/lib/python3.8/site-packages/discord/ext/commands/core.py", line 83, in wrapped
    ret = await coro(*args, **kwargs)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/adventurealert/adventurealert.py", line 156, in adventure_users
    if ctx.author.id in await self.config.guild(ctx.guild).adventure_users():
  File "/.../cat38/lib/python3.8/site-packages/redbot/core/config.py", line 976, in guild
    return self._get_base_group(self.GUILD, str(guild.id))
AttributeError: 'NoneType' object has no attribute 'id'
```