### PR TITLE
Fix missing event_type when processing command.

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -237,7 +237,9 @@ class EventMixin:
         )
         if embed_links:
             embed = discord.Embed(
-                description=message.content, colour=await self.get_event_colour(channel), timestamp=time,
+                description=message.content,
+                colour=await self.get_event_colour(channel, "commands_used"),
+                timestamp=time,
             )
             embed.add_field(name=_("Channel"), value=message.channel.mention)
             embed.add_field(name=_("Can Run"), value=str(can_run))


### PR DESCRIPTION
To fix this issue:

```py
Ignoring exception in on_command
Traceback (most recent call last):
  File "/home/redbot/.local/lib/python3.8/site-packages/discord/client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "/home/redbot/.local/share/Red-DiscordBot/data/Dronefly/cogs/CogManager/cogs/extendedmodlog/eventmixin.py", line 240, in on_command
    description=message.content, colour=await self.get_event_colour(channel), timestamp=time,
TypeError: get_event_colour() missing 1 required positional argument: 'event_type'
```
