### PR TITLE
[NotSoBot] fix NumPy FutureWarning with merge command

### DIFF
--- a/notsobot/notsobot.py
+++ b/notsobot/notsobot.py
@@ -830,11 +830,11 @@ class NotSoBot(commands.Cog):
             if vertical:
                 # Vertical
                 max_shape = sorted([(np.sum(i.size), i.size) for i in imgs])[1][1]
-                imgs_comb = np.vstack((np.asarray(i.resize(max_shape)) for i in imgs))
+                imgs_comb = np.vstack([np.asarray(i.resize(max_shape)) for i in imgs])
             else:
                 # Horizontal
                 min_shape = sorted([(np.sum(i.size), i.size) for i in imgs])[0][1]
-                imgs_comb = np.hstack((np.asarray(i.resize(min_shape)) for i in imgs))
+                imgs_comb = np.hstack([np.asarray(i.resize(min_shape)) for i in imgs])
             imgs_comb = Image.fromarray(imgs_comb)
             final = BytesIO()
             imgs_comb.save(final, "png")


### PR DESCRIPTION
See this stackoverflow issue for reference: https://stackoverflow.com/questions/62703814/futurewarning-arrays-to-stack-must-be-passed-as-a-sequence-type-such-as-list

Resolves #135 