### PR TITLE
[Spotify] 1.4.5 Improve Queuing tracks

### DIFF
--- a/spotify/emojis.json
+++ b/spotify/emojis.json
@@ -15,5 +15,6 @@
    "playall":"⏏",
    "shuffle":"🔀",
    "back_left":"◀",
-   "play":"▶"
+   "play":"▶",
+   "queue": "🇶"
 }

--- a/spotify/helpers.py
+++ b/spotify/helpers.py
@@ -284,6 +284,7 @@ class RecommendationsConverter(Converter):
             "genres": genres if genres else None,
             "track_ids": tracks if tracks else None,
             "limit": 100,
+            "market": "from_token",
         }
         for match in find_extra:
             try:


### PR DESCRIPTION
Include queue as option for reaction listen and improve queuing with multiple tracks.

Add menu customization per guild for clearing reactions, deletion, and timeout.

Made default timeout for menus to be 2 minutes.