### PR TITLE
[InviteBlockList] 1.1.0 Add support for specific immunities

### DIFF
--- a/inviteblocklist/inviteblocklist.py
+++ b/inviteblocklist/inviteblocklist.py
@@ -1,12 +1,12 @@
 import logging
 import re
-from typing import List, Pattern, Union
+from typing import Pattern, Union
 
 import discord
 from discord.ext.commands.converter import IDConverter, InviteConverter
 from discord.ext.commands.errors import BadArgument
 from redbot.core import Config, VersionInfo, commands, version_info
-from redbot.core.i18n import Translator, cog_i18n
+from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list, pagify
 
 log = logging.getLogger("red.trusty-cogs.inviteblocklist")
@@ -28,15 +28,68 @@ class ValidServerID(IDConverter):
         return guild_id
 
 
+class ChannelUserRole(IDConverter):
+    """
+    This will check to see if the provided argument is a channel, user, or role
+
+    Guidance code on how to do this from:
+    https://github.com/Rapptz/discord.py/blob/rewrite/discord/ext/commands/converter.py#L85
+    https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/cogs/mod/mod.py#L24
+    """
+
+    async def convert(
+        self, ctx: commands.Context, argument: str
+    ) -> Union[discord.TextChannel, discord.Member, discord.Role]:
+        guild = ctx.guild
+        result = None
+        id_match = self._get_id_match(argument)
+        channel_match = re.match(r"<#([0-9]+)>$", argument)
+        member_match = re.match(r"<@!?([0-9]+)>$", argument)
+        role_match = re.match(r"<@&([0-9]+)>$", argument)
+        for converter in ["channel", "role", "member"]:
+            if converter == "channel":
+                match = id_match or channel_match
+                if match:
+                    channel_id = match.group(1)
+                    result = guild.get_channel(int(channel_id))
+                else:
+                    result = discord.utils.get(guild.text_channels, name=argument)
+            if converter == "member":
+                match = id_match or member_match
+                if match:
+                    member_id = match.group(1)
+                    result = guild.get_member(int(member_id))
+                else:
+                    result = guild.get_member_named(argument)
+            if converter == "role":
+                match = id_match or role_match
+                if match:
+                    role_id = match.group(1)
+                    result = guild.get_role(int(role_id))
+                else:
+                    result = discord.utils.get(guild._roles.values(), name=argument)
+            if result:
+                break
+        if not result:
+            msg = ("{arg} is not a valid channel, user or role.").format(arg=argument)
+            raise BadArgument(msg)
+        return result
+
+
 class InviteBlocklist(commands.Cog):
 
     __author__ = ["TrustyJAID"]
-    __version__ = "1.0.0"
+    __version__ = "1.1.0"
 
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(self, identifier=218773382617890828)
-        self.config.register_guild(blacklist=[], whitelist=[], all_invites=False)
+        self.config.register_guild(
+            blacklist=[],
+            whitelist=[],
+            all_invites=False,
+            immunity_list=[],
+        )
 
     async def red_delete_data_for_user(self, **kwargs):
         """
@@ -58,6 +111,8 @@ class InviteBlocklist(commands.Cog):
         Handle messages edited with links
         """
         if payload.cached_message:
+            if not payload.cached_message.guild:
+                return
             await self._handle_message_search(payload.cached_message)
             return
         chan = self.bot.get_channel(payload.channel_id)
@@ -67,13 +122,40 @@ class InviteBlocklist(commands.Cog):
             return
         await self._handle_message_search(msg)
 
+    async def check_immunity_list(self, message: discord.Message) -> bool:
+        is_immune = False
+        if not message.guild:
+            return True
+        if await self.bot.is_owner(message.author):
+            return True
+        global_perms = await self.bot.allowed_by_whitelist_blacklist(message.author)
+        if not global_perms:
+            return global_perms
+        immunity_list = await self.config.guild(message.guild).immunity_list()
+        channel = message.channel
+        if immunity_list:
+            if channel.id in immunity_list:
+                is_immune = True
+            if channel.category_id and channel.category_id in immunity_list:
+                is_immune = True
+            if message.author.id in immunity_list:
+                is_immune = True
+            for role in getattr(message.author, "roles", []):
+                if role.is_default():
+                    continue
+                if role.id in immunity_list:
+                    is_immune = True
+        return is_immune
+
     async def _handle_message_search(self, message: discord.Message):
         if await self.bot.is_automod_immune(message.author):
             return
         if version_info >= VersionInfo.from_str("3.4.0"):
             if await self.bot.cog_disabled_in_guild(self, message.guild):
                 return
-
+        if await self.check_immunity_list(message) is True:
+            log.debug("Message context is immune from invite blocklist")
+            return
         find = INVITE_RE.findall(message.clean_content)
         guild = message.guild
         if find and await self.config.guild(message.guild).all_invites():
@@ -144,6 +226,17 @@ class InviteBlocklist(commands.Cog):
         """
         pass
 
+    @invite_block.group(name="immunity", aliases=["immune"])
+    async def invite_immunity(self, ctx: commands.Context):
+        """
+        Commands for fine tuning allowed channels, users, or roles
+        """
+        pass
+
+    ##########################################################################################
+    #                                    Blocklist Settings                                  #
+    ##########################################################################################
+
     @invite_block.command()
     @commands.mod_or_permissions(manage_messages=True)
     async def blockall(self, ctx: commands.Context, set_to: bool):
@@ -178,16 +271,54 @@ class InviteBlocklist(commands.Cog):
                     if i not in blacklist:
                         blacklist.append(i)
                         guilds_blocked.append(str(i))
-                else:
+                if isinstance(i, discord.Invite):
                     if i.guild and i.guild.id not in blacklist:
                         blacklist.append(i.guild.id)
                         guilds_blocked.append(f"{i.guild.name} - {i.guild.id}")
+                else:
+                    if i.id in blacklist:
+                        guilds_blocked.append(f"{i.name} - {i.id}")
+                        blacklist.append(i.id)
         if guilds_blocked:
             await ctx.send(
                 _("Now blocking invites from {guild}.").format(guild=humanize_list(guilds_blocked))
             )
         else:
             await ctx.send(_("None of the provided invite links or guild ID's are new."))
+
+    @invite_blocklist.group(name="remove", aliases=["del", "rem"])
+    async def remove_from_blocklist(
+        self,
+        ctx: commands.Context,
+        *thing_to_block: Union[InviteConverter, ValidServerID],
+    ):
+        """
+        Add a guild ID to the blocklist, providing an invite link will also work
+
+        `[invite_or_guild_id]` The guild ID or invite to the guild you not longer want to have
+        invite links blocked from.
+        """
+        guilds_blocked = []
+        async with self.config.guild(ctx.guild).blacklist() as blacklist:
+            for i in thing_to_block:
+                if isinstance(i, int):
+                    if i in blacklist:
+                        blacklist.remove(i)
+                        guilds_blocked.append(str(i))
+                if isinstance(i, discord.Invite):
+                    if i.guild and i.guild.id in blacklist:
+                        guilds_blocked.append(f"{i.guild.name} - {i.guild.id}")
+                        blacklist.remove(i.guild.id)
+                else:
+                    if i.id in blacklist:
+                        guilds_blocked.append(f"{i.name} - {i.id}")
+                        blacklist.remove(i.id)
+        if guilds_blocked:
+            await ctx.send(
+                _("Removed {guild} from blocklist.").format(guild=humanize_list(guilds_blocked))
+            )
+        else:
+            await ctx.send(_("None of the provided invite links or guild ID's are being blocked."))
 
     @invite_blocklist.command(name="info")
     async def blocklist_info(self, ctx: commands.Context):
@@ -198,37 +329,19 @@ class InviteBlocklist(commands.Cog):
         msg = _("__Guild ID's Blocked__:\n{guilds}").format(
             guilds="\n".join(str(g) for g in blacklist)
         )
-
+        block_list = await self.config.guild(ctx.guild).channel_user_role_allow()
+        if block_list:
+            msg += _("__Blocked Channels, Users, and Roles:__\n{chan_user_roel}").format(
+                chan_user_role="\n".join(
+                    await ChannelUserRole().convert(ctx, str(obj_id)) for obj_id in block_list
+                )
+            )
         for page in pagify(msg):
             await ctx.maybe_send_embed(page)
 
-    @invite_blocklist.command(name="remove", aliases=["del", "rem"])
-    async def remove_from_blocklist(
-        self, ctx: commands.Context, *invite_or_guild_id: Union[InviteConverter, ValidServerID]
-    ):
-        """
-        Add a guild ID to the blocklist, providing an invite link will also work
-
-        `[invite_or_guild_id]` The guild ID or invite to the guild you not longer want to have
-        invite links blocked from.
-        """
-        guilds_blocked = []
-        async with self.config.guild(ctx.guild).blacklist() as blacklist:
-            for i in invite_or_guild_id:
-                if isinstance(i, int):
-                    if i in blacklist:
-                        blacklist.remove(i)
-                        guilds_blocked.append(str(i))
-                else:
-                    if i.guild and i.guild.id in blacklist:
-                        guilds_blocked.append(f"{i.guild.name} - {i.guild.id}")
-                        blacklist.remove(i.guild.id)
-        if guilds_blocked:
-            await ctx.send(
-                _("Removed {guild} from blocklist.").format(guild=humanize_list(guilds_blocked))
-            )
-        else:
-            await ctx.send(_("None of the provided invite links or guild ID's are being blocked."))
+    ##########################################################################################
+    #                                    Alowlist Settings                                   #
+    ##########################################################################################
 
     @invite_allowlist.command(name="add")
     async def add_to_allowlist(
@@ -257,18 +370,6 @@ class InviteBlocklist(commands.Cog):
             )
         else:
             await ctx.send(_("None of the provided invite links or ID's are new."))
-
-    @invite_allowlist.command(name="info")
-    async def allowlist_info(self, ctx: commands.Context):
-        """
-        Show what guild ID's are in the invite link allowlist
-        """
-        whitelist = await self.config.guild(ctx.guild).whitelist()
-        msg = _("__Guild ID's Allowed__:\n{guilds}").format(
-            guilds="\n".join(str(g) for g in whitelist)
-        )
-        for page in pagify(msg):
-            await ctx.maybe_send_embed(page)
 
     @invite_allowlist.command(name="remove", aliases=["del", "rem"])
     async def remove_from_allowlist(
@@ -299,3 +400,91 @@ class InviteBlocklist(commands.Cog):
             await ctx.send(
                 _("None of the provided invite links or guild ID's are currently allowed.")
             )
+
+    @invite_allowlist.command(name="info")
+    async def allowlist_info(self, ctx: commands.Context):
+        """
+        Show what guild ID's are in the invite link allowlist
+        """
+        whitelist = await self.config.guild(ctx.guild).whitelist()
+        msg = _("__Guild ID's Allowed__:\n{guilds}").format(
+            guilds="\n".join(str(g) for g in whitelist)
+        )
+        allow_list = await self.config.guild(ctx.guild).channel_user_role_allow()
+        if allow_list:
+            msg += _("__Allowed Channels, Users, and Roles:__\n{chan_user_roel}").format(
+                chan_user_role="\n".join(
+                    await ChannelUserRole().convert(ctx, str(obj_id)) for obj_id in allow_list
+                )
+            )
+        for page in pagify(msg):
+            await ctx.maybe_send_embed(page)
+
+    ##########################################################################################
+    #                                  Immunity Settings                                     #
+    ##########################################################################################
+
+    @invite_immunity.command(name="add")
+    async def add_to_invite_immunity(
+        self, ctx: commands.Context, *channel_user_role: ChannelUserRole
+    ):
+        """
+        Add a guild ID to the allowlist, providing an invite link will also work
+
+        `[channel_user_role...]` is the channel, user or role to whitelist
+        (You can supply more than one of any at a time)
+        """
+        if len(channel_user_role) < 1:
+            return await ctx.send(
+                _("You must supply 1 or more channels users or roles to be allowed.")
+            )
+        async with self.config.guild(ctx.guild).immunity_list() as whitelist:
+            for obj in channel_user_role:
+                if obj.id not in whitelist:
+                    whitelist.append(obj.id)
+        msg = _("`{list_type}` added to the whitelist.")
+        list_type = humanize_list([c.name for c in channel_user_role])
+        await ctx.send(msg.format(list_type=list_type))
+
+    @invite_immunity.command(name="remove", aliases=["del", "rem"])
+    async def remove_from_invite_immunity(
+        self, ctx: commands.Context, *channel_user_role: ChannelUserRole
+    ):
+        """
+        Add a guild ID to the allowlist, providing an invite link will also work
+
+        `[channel_user_role...]` is the channel, user or role to remove from the whitelist
+        (You can supply more than one of any at a time)
+        """
+        if len(channel_user_role) < 1:
+            return await ctx.send(
+                _("You must supply 1 or more channels users or roles to be whitelisted.")
+            )
+        async with self.config.guild(ctx.guild).immunity_list() as whitelist:
+            for obj in channel_user_role:
+                if obj.id in whitelist:
+                    whitelist.remove(obj.id)
+        msg = _("`{list_type}` removed from the whitelist.")
+        list_type = humanize_list([c.name for c in channel_user_role])
+        await ctx.send(msg.format(list_type=list_type))
+
+    @invite_immunity.command(name="info")
+    async def allowlist_context_info(self, ctx: commands.Context):
+        """
+        Show what channels, users, and roles are in the invite link allowlist
+        """
+        msg = _("Invite immunity list for {guild}:\n").format(guild=ctx.guild.name)
+        whitelist = await self.config.guild(ctx.guild).immunity_list()
+        can_embed = ctx.channel.permissions_for(ctx.me).embed_links
+        for obj_id in whitelist:
+            obj = await ChannelUserRole().convert(ctx, str(obj_id))
+            if isinstance(obj, discord.TextChannel):
+                msg += f"{obj.mention}\n"
+                continue
+            if can_embed:
+                msg += f"{obj.mention}\n"
+                continue
+            else:
+                msg += f"{obj.name}\n"
+        for page in pagify(msg):
+            await ctx.maybe_send_embed(page)


### PR DESCRIPTION
This adds support for immunity for certain channels, users, and roles.

This also takes into account local and global bot blacklist/whitelist ensuring that if a user is present in the bots local and local blacklist/whitelist the search for invite links will always be run.