### PR TITLE
[ExtendedModLog] Fix ignored channel at `on_guild_channel_update` event

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -870,7 +870,7 @@ class EventMixin:
                 return
         if not self.settings[guild.id]["channel_change"]["enabled"]:
             return
-        if await self.is_ignored_channel(guild, message_channel):
+        if await self.is_ignored_channel(guild, before):
             return
         try:
             channel = await self.modlog_channel(guild, "channel_change")


### PR DESCRIPTION
This just fixes message_channel that was not defined.