### PR TITLE
[ExtendedModLog] Avoid potential place of resource leak

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -617,16 +617,16 @@ class EventMixin:
         """
         This is only used to track that the user was banned and not kicked/removed
         """
-        if guild not in self._ban_cache:
-            self._ban_cache[guild] = [member]
+        if guild.id not in self._ban_cache:
+            self._ban_cache[guild.id] = [member.id]
         else:
-            self._ban_cache[guild].append(member)
+            self._ban_cache[guild.id].append(member.id)
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
         guild = member.guild
         await asyncio.sleep(5)
-        if guild in self._ban_cache and member in self._ban_cache[guild]:
+        if guild.id in self._ban_cache and member.id in self._ban_cache[guild.id]:
             # was a ban so we can leave early
             return
         if guild.id not in self.settings:


### PR DESCRIPTION
Storing guild or member objects long-term can result in a resource leak when, for example, a guild object gets invalidated.