### PR TITLE
[ReTrigger]handle unchunked guild owner ID

### DIFF
--- a/retrigger/converters.py
+++ b/retrigger/converters.py
@@ -88,7 +88,7 @@ class MultiResponse(Converter):
                 raise BadArgument(_("Not creating trigger."))
 
         def author_perms(ctx: commands.Context, role: discord.Role) -> bool:
-            if ctx.author.id == ctx.guild.owner.id:
+            if ctx.author.id == ctx.guild.owner_id: #handles case where guild is not chunked and calls for the ID thru the endpoint instead
                 return True
             return role < ctx.author.top_role
 

--- a/retrigger/retrigger.py
+++ b/retrigger/retrigger.py
@@ -824,7 +824,7 @@ class ReTrigger(TriggerHandler, commands.Cog):
         for role in roles:
             if role >= ctx.me.top_role:
                 return await ctx.send(_("I can't assign roles higher than my own."))
-            if ctx.author.id == ctx.guild.owner.id:
+            if ctx.author.id == ctx.guild.owner_id:
                 continue
             if role >= ctx.author.top_role:
                 return await ctx.send(
@@ -1732,7 +1732,7 @@ class ReTrigger(TriggerHandler, commands.Cog):
         for role in roles:
             if role >= ctx.me.top_role:
                 return await ctx.send(_("I can't assign roles higher than my own."))
-            if ctx.author.id == ctx.guild.owner.id:
+            if ctx.author.id == ctx.guild.owner_id:
                 continue
             if role >= ctx.author.top_role:
                 return await ctx.send(
@@ -1775,7 +1775,7 @@ class ReTrigger(TriggerHandler, commands.Cog):
         for role in roles:
             if role >= ctx.me.top_role:
                 return await ctx.send(_("I can't remove roles higher than my own."))
-            if ctx.author.id == ctx.guild.owner.id:
+            if ctx.author.id == ctx.guild.owner_id:
                 continue
             if role >= ctx.author.top_role:
                 return await ctx.send(


### PR DESCRIPTION
handles unchunked guilds where changing guild.owner.id (cache) for guild.owner_id (grabbed from api)

Otherwise, it returns Nonetype if the guild is not chunked when calling guild.owner.id