### PR TITLE
[Loaddev] Typo fixes

### DIFF
--- a/loaddev/loaddev.py
+++ b/loaddev/loaddev.py
@@ -83,7 +83,7 @@ class LoadDev(commands.Cog):
     @devset.command()
     async def replacemock(self, ctx: commands.Context, replacement: Optional[str]):
         """
-        Set an automatic replacemetn for `[p]mock` when auto loading dev.
+        Set an automatic replacement for `[p]mock` when auto loading dev.
         """
         await self.config.replace_mock.set(replacement)
         if replacement:


### PR DESCRIPTION
Very small typo: `replacemetn` -> `replacement`.