### PR TITLE
[RoleTools] Fix error with roletools cleanup

### DIFF
--- a/roletools/roletools.py
+++ b/roletools/roletools.py
@@ -622,8 +622,9 @@ class RoleTools(RoleEvents, commands.Cog):
                     if not channel:
                         to_remove.append((key, role_id))
                         continue
-                    message = await channel.fetch_message(int(message_id))
-                    if not message:
+                    try:
+                        await channel.fetch_message(int(message_id))
+                    except Exception:
                         to_remove.append((key, role_id))
                         continue
                     role = guild.get_role(int(role_id))


### PR DESCRIPTION
The current behaviour is that the command will error when the message is deleted.

(from DarkJarris https://discord.com/channels/240154543684321280/461417772115558410/821420623896379392)
```py
Mar 16 17:23:40 localhost python[32729]: Traceback (most recent call last):
Mar 16 17:23:40 localhost python[32729]:   File "/home/matthew/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
Mar 16 17:23:40 localhost python[32729]:     ret = await coro(*args, **kwargs)
Mar 16 17:23:40 localhost python[32729]:   File "/home/matthew/.local/share/Red-DiscordBot/data/CF_Discord/cogs/CogManager/cogs/roletools/roletools.py", line 625, in cleanup
Mar 16 17:23:40 localhost python[32729]:     message = await channel.fetch_message(int(message_id))
Mar 16 17:23:40 localhost python[32729]:   File "/home/matthew/redenv/lib/python3.8/site-packages/discord/abc.py", line 970, in fetch_message
Mar 16 17:23:40 localhost python[32729]:     data = await self._state.http.get_message(channel.id, id)
Mar 16 17:23:40 localhost python[32729]:   File "/home/matthew/redenv/lib/python3.8/site-packages/discord/http.py", line 243, in request
Mar 16 17:23:40 localhost python[32729]:     raise NotFound(r, data)
Mar 16 17:23:40 localhost python[32729]: discord.errors.NotFound: 404 Not Found (error code: 10008): Unknown Message
```

This PR will catch all exceptions (eg NotFound, Forbidden), and if so add it to the to_remove list.