### PR TITLE
[MentionPrefix] Deny listener from other bots

### DIFF
--- a/mentionprefix/mentionprefix.py
+++ b/mentionprefix/mentionprefix.py
@@ -84,6 +84,8 @@ class MentionPrefix(commands.Cog):
         author = message.author
         guild = message.guild
         guild_id = guild.id if guild else None
+        if author.bot:
+            return
         if guild_id in self.disable_in:
             return
         if guild_id not in self.antispam:


### PR DESCRIPTION
IMO, although it would be impractical, mentionprefix shouldn't respond to other bots