### PR TITLE
Remove bot.get_channel

### DIFF
--- a/roletools/events.py
+++ b/roletools/events.py
@@ -21,8 +21,7 @@ class RoleEvents:
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
-        channel = self.bot.get_channel(payload.channel_id)
-        guild = getattr(channel, "guild", None)
+        guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
         if await self.bot.cog_disabled_in_guild(self, guild):
@@ -56,8 +55,7 @@ class RoleEvents:
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
-        channel = self.bot.get_channel(payload.channel_id)
-        guild = getattr(channel, "guild", None)
+        guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
         if await self.bot.cog_disabled_in_guild(self, guild):

--- a/spotify/spotify.py
+++ b/spotify/spotify.py
@@ -307,7 +307,7 @@ class Spotify(commands.Cog):
         if await self.bot.cog_disabled_in_guild(self, guild):
             return
 
-        channel = self.bot.get_channel(payload.channel_id)
+        channel = guild.get_channel(payload.channel_id)
         try:
             message = await channel.fetch_message(payload.message_id)
         except Exception:

--- a/starboard/events.py
+++ b/starboard/events.py
@@ -254,7 +254,7 @@ class StarboardEvents:
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
-        channel = guild.get_channel(id=payload.channel_id)
+        channel = guild.get_channel(payload.channel_id)
 
         if version_info >= VersionInfo.from_str("3.4.0"):
             if await self.bot.cog_disabled_in_guild(self, guild):
@@ -282,7 +282,7 @@ class StarboardEvents:
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
-        channel = guild.get_channel(id=payload.channel_id)
+        channel = guild.get_channel(payload.channel_id)
 
         if guild.id not in self.starboards:
             return

--- a/starboard/events.py
+++ b/starboard/events.py
@@ -251,12 +251,11 @@ class StarboardEvents:
 
     @commands.Cog.listener()
     async def on_raw_reaction_clear(self, payload: discord.RawReactionActionEvent) -> None:
-        channel = self.bot.get_channel(id=payload.channel_id)
-        try:
-            guild = channel.guild
-        except AttributeError:
-            # DMChannels don't have guilds
+        guild = self.bot.get_guild(payload.guild_id)
+        if not guild:
             return
+        channel = guild.get_channel(id=payload.channel_id)
+
         if version_info >= VersionInfo.from_str("3.4.0"):
             if await self.bot.cog_disabled_in_guild(self, guild):
                 return
@@ -269,7 +268,7 @@ class StarboardEvents:
         # starboards = await self.config.guild(guild).starboards()
         for name, starboard in self.starboards[guild.id].items():
             # starboard = StarboardEntry.from_json(s_board)
-            star_channel = self.bot.get_channel(starboard.channel)
+            star_channel = guild.get_channel(starboard.channel)
             if not star_channel:
                 continue
             async with starboard.lock:
@@ -280,12 +279,11 @@ class StarboardEvents:
         payload: Union[discord.RawReactionActionEvent, FakePayload],
         remove: Optional[int] = None,
     ) -> None:
-        channel = self.bot.get_channel(id=payload.channel_id)
-        try:
-            guild = channel.guild
-        except AttributeError:
-            # DMChannels don't have guilds
+        guild = self.bot.get_guild(payload.guild_id)
+        if not guild:
             return
+        channel = guild.get_channel(id=payload.channel_id)
+
         if guild.id not in self.starboards:
             return
         if version_info >= VersionInfo.from_str("3.4.0"):


### PR DESCRIPTION
This PR removes the usage of `bot.get_channel` in several listeners and replaces them with `Guild.get_channel`, as `bot.get_channel` can be a taxing call on large bots. After profiling Noumenon, I found that starboard's on_raw_reaction event was its 3rd most expensive event, simply due to the usage of `bot.get_channel`.