### PR TITLE
[Tarot] Handle cards not in card range

### DIFF
--- a/tarot/tarotreading.py
+++ b/tarot/tarotreading.py
@@ -14,7 +14,7 @@ class TarotReading(commands.Cog):
     """
 
     __author__ = ["TrustyJAID"]
-    __version__ = "1.0.0"
+    __version__ = "1.0.1"
 
     def __init__(self, bot):
         self.bot = bot
@@ -113,7 +113,7 @@ class TarotReading(commands.Cog):
         elif msg.isdigit() and int(msg) > 0 and int(msg) < 79:
             card = self.tarot_cards[str(msg)]
 
-        elif not msg.isdigit():
+        elif not msg.isdigit() or int(msg) < 0 or int(msg) > 79:
             for cards in self.tarot_cards:
                 if msg.lower() in self.tarot_cards[cards]["card_name"].lower():
                     card = self.tarot_cards[cards]


### PR DESCRIPTION
Fixes an issue where a card int could be out of range. For example, I had a user try to use [p]tarot card 80, which is out of the 78 card range, and got

```
[2021-03-25 01:11:21] [ERROR] red: Exception in command 'tarot card'
Traceback (most recent call last):
  File "/.../lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/tarot/tarotreading.py", line 117, in _card
    title=card["card_name"],
TypeError: 'NoneType' object is not subscriptable
```