### PR TITLE
[Covfefe] Remove bare exception

### DIFF
--- a/covfefe/covfefe.py
+++ b/covfefe/covfefe.py
@@ -19,7 +19,7 @@ class Covfefe(commands.Cog):
         try:
             b, c, v = re.findall(f"(.*?[{k}([^{k}.*?([{k}", x)[0]
             return b + c + (("bcdfgkpstvz" + c)["pgtvkgbzdfs".find(c)] + v) * 2
-        except:
+        except IndexError:
             return None
 
     async def red_delete_data_for_user(self, **kwargs):


### PR DESCRIPTION
I'm pretty sure `IndexError` would be the only possible exception here, which would be better than just having a bare exception.