### PR TITLE
Hockey 3.0.0

### DIFF
--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -8,7 +8,14 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 
 from .game import Game
-from .helper import HockeyStandings, HockeyStates, HockeyTeams, TeamDateFinder, YearFinder
+from .helper import (
+    HockeyStandings,
+    HockeyStates,
+    HockeyTeams,
+    TeamDateFinder,
+    YearFinder,
+    TimezoneFinder,
+)
 from .pickems import Pickems
 
 
@@ -195,6 +202,14 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def set_hockey_timezone(self, ctx: commands.Context, timezone: TimezoneFinder = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def list_hockey_timezones(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
     async def leaderboardset(
         self,
         ctx: commands.Context,
@@ -322,6 +337,12 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def edit_pickems_message(
+        self, channel: discord.TextChannel, message_id: int, content: str
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
     async def create_weekly_pickems_pages(self, guilds: List[discord.Guild]) -> bool:
         raise NotImplementedError()
 
@@ -346,7 +367,11 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def create_pickems_game_msg(self, channel: discord.TextChannel, game: Game):
+    async def make_pickems_msg(self, guild: discord.Guild, game: Game) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_pickems_game_message(self, channel: discord.TextChannel, game: Game):
         raise NotImplementedError()
 
     @abstractmethod
@@ -367,6 +392,14 @@ class MixinMeta(ABC):
 
     @abstractmethod
     async def pickems_settings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_pickems_message(self, ctx: commands.Context, *, message: Optional[str] = ""):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_pickems_timezone(self, ctx: commands.Context, timezone: TimezoneFinder = None):
         raise NotImplementedError()
 
     @abstractmethod

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -322,9 +322,7 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def create_weekly_pickems_pages(
-        self, guilds: List[discord.Guild], game_obj: Game
-    ) -> bool:
+    async def create_weekly_pickems_pages(self, guilds: List[discord.Guild]) -> bool:
         raise NotImplementedError()
 
     @abstractmethod

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -177,9 +177,14 @@ class MixinMeta(ABC):
     # hockeyset.py                                                        #
     #######################################################################
 
-    @abstractmethod
+    @commands.group(name="hockeyset", aliases=["nhlset"])
+    @commands.guild_only()
+    @commands.mod_or_permissions(manage_channels=True)
     async def hockeyset_commands(self, ctx: commands.Context):
-        raise NotImplementedError()
+        """
+        Setup Hockey commands for the server
+        """
+        pass
 
     @abstractmethod
     async def hockey_settings(self, ctx: commands.Context):
@@ -284,52 +289,6 @@ class MixinMeta(ABC):
     ):
         raise NotImplementedError()
 
-    @abstractmethod
-    async def pickems_commands(self, ctx: commands.Context):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def setup_auto_pickems(
-        self, ctx: commands.Context, category: Optional[discord.CategoryChannel] = None
-    ):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def delete_auto_pickems(self, ctx: commands.Context):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def toggle_auto_pickems(self, ctx: commands.Context):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def pickems_page(self, ctx, date: Optional[str] = None):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def rempickem(self, ctx: commands.Context, true_or_false: bool):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def pickems_leaderboard_commands(self, ctx: commands.Context):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool):
-        raise NotImplementedError()
-
     #######################################################################
     # pickems.py                                                          #
     #######################################################################
@@ -402,6 +361,56 @@ class MixinMeta(ABC):
 
     @abstractmethod
     async def tally_leaderboard(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_settings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def setup_auto_pickems(
+        self, ctx: commands.Context, category: Optional[discord.CategoryChannel] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_auto_pickems(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def toggle_auto_pickems(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_page(self, ctx, date: Optional[str] = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def rempickem(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_leaderboard_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool):
         raise NotImplementedError()
 
     #######################################################################

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -1,6 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import List, Literal, Optional
+from datetime import datetime
+from typing import List, Literal, Optional, Dict
 
 import aiohttp
 import discord
@@ -41,41 +42,43 @@ class MixinMeta(ABC):
     #######################################################################
 
     @abstractmethod
-    async def hockey_commands(self, ctx: commands.Context):
+    async def hockey_commands(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def version(self, ctx: commands.Context):
+    async def version(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def hockeyhub(self, ctx: commands.Context, *, search: str):
+    async def hockeyhub(self, ctx: commands.Context, *, search: str) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def team_role(self, ctx: commands.Context, *, team: HockeyTeams):
+    async def team_role(self, ctx: commands.Context, *, team: HockeyTeams) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def team_goals(self, ctx: commands.Context, *, team: HockeyTeams = None):
+    async def team_goals(self, ctx: commands.Context, *, team: HockeyTeams = None) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None):
+    async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def games(self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}):
+    async def games(
+        self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def schedule(
         self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def player_id_lookup(self, name: str):
+    async def player_id_lookup(self, name: str) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -84,35 +87,35 @@ class MixinMeta(ABC):
         ctx: commands.Context,
         *,
         search: str,
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def roster(
         self, ctx: commands.Context, season: Optional[YearFinder] = None, *, search: HockeyTeams
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def rules(self, ctx: commands.Context):
+    async def rules(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def post_leaderboard(
         self, ctx: commands.Context, leaderboard_type: Literal["season", "weekly", "worst"]
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def leaderboard(self, ctx: commands.Context, leaderboard_type: str = "seasonal"):
+    async def leaderboard(self, ctx: commands.Context, leaderboard_type: str = "seasonal") -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules):
+    async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def otherdiscords(self, ctx: commands.Context, team: HockeyTeams):
+    async def otherdiscords(self, ctx: commands.Context, team: HockeyTeams) -> None:
         raise NotImplementedError()
 
     #######################################################################
@@ -120,39 +123,39 @@ class MixinMeta(ABC):
     #######################################################################
 
     @abstractmethod
-    async def gdc(self, ctx: commands.Context):
+    async def gdc(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_settings(self, ctx: commands.Context):
+    async def gdc_settings(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_delete(self, ctx: commands.Context):
+    async def gdc_delete(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_default_game_state(self, ctx: commands.Context, *state: HockeyStates):
+    async def gdc_default_game_state(self, ctx: commands.Context, *state: HockeyStates) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_create(self, ctx: commands.Context):
+    async def gdc_create(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_toggle(self, ctx: commands.Context):
+    async def gdc_toggle(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_category(self, ctx: commands.Context, category: discord.CategoryChannel):
+    async def gdc_category(self, ctx: commands.Context, category: discord.CategoryChannel) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def gdc_autodelete(self, ctx: commands.Context):
+    async def gdc_autodelete(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def test_gdc(self, ctx: commands.Context):
+    async def test_gdc(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -162,23 +165,23 @@ class MixinMeta(ABC):
         team: HockeyTeams,
         category: discord.CategoryChannel = None,
         delete_gdc: bool = True,
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def get_chn_name(self, game: Game):
+    async def get_chn_name(self, game: Game) -> str:
         raise NotImplementedError()
 
     @abstractmethod
-    async def check_new_gdc(self):
+    async def check_new_gdc(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def create_gdc(self, guild: discord.Guild, game_data: Optional[Game] = None):
+    async def create_gdc(self, guild: discord.Guild, game_data: Optional[Game] = None) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def delete_gdc(self, guild: discord.Guild):
+    async def delete_gdc(self, guild: discord.Guild) -> None:
         raise NotImplementedError()
 
     #######################################################################
@@ -188,28 +191,28 @@ class MixinMeta(ABC):
     @commands.group(name="hockeyset", aliases=["nhlset"])
     @commands.guild_only()
     @commands.mod_or_permissions(manage_channels=True)
-    async def hockeyset_commands(self, ctx: commands.Context):
+    async def hockeyset_commands(self, ctx: commands.Context) -> None:
         """
         Setup Hockey commands for the server
         """
         pass
 
     @abstractmethod
-    async def hockey_settings(self, ctx: commands.Context):
+    async def hockey_settings(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def reset(self, ctx: commands.Context):
+    async def reset(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_hockey_timezone(
         self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def list_hockey_timezones(self, ctx: commands.Context):
+    async def list_hockey_timezones(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -220,7 +223,7 @@ class MixinMeta(ABC):
         season: int,
         weekly: int = None,
         total: int = None,
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -228,43 +231,43 @@ class MixinMeta(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def hockey_notifications(self, ctx: commands.Context):
+    async def hockey_notifications(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_goal_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_ot_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_so_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_game_start_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_channel_goal_notification_style(
         self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_channel_game_start_notification_style(
         self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -273,7 +276,7 @@ class MixinMeta(ABC):
         ctx: commands.Context,
         standings_type: str,
         channel: Optional[discord.TextChannel] = None,
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -283,19 +286,19 @@ class MixinMeta(ABC):
     @abstractmethod
     async def set_game_state_updates(
         self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_game_publish_updates(
         self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def add_goals(
         self, ctx: commands.Context, team: HockeyTeams, channel: Optional[discord.TextChannel]
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -304,27 +307,37 @@ class MixinMeta(ABC):
         ctx: commands.Context,
         team: Optional[HockeyTeams] = None,
         channel: Optional[discord.TextChannel] = None,
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     #######################################################################
-    # pickems.py                                                          #
+    # hockeypickems.py                                                    #
     #######################################################################
 
     @abstractmethod
-    async def pickems_loop(self):
+    async def on_hockey_preview_message(
+        self, channel: discord.TextChannel, message: discord.Message, game: Game
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def save_pickems_data(self):
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def after_pickems_loop(self):
+    async def pickems_loop(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def before_pickems_loop(self):
+    async def save_pickems_data(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def after_pickems_loop(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def before_pickems_loop(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -336,17 +349,13 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def set_guild_pickem_winner(self, game: Game):
+    async def set_guild_pickem_winner(self, game: Game) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def edit_pickems_message(
         self, channel: discord.TextChannel, message_id: int, content: str
-    ):
-        raise NotImplementedError()
-
-    @abstractmethod
-    async def create_weekly_pickems_pages(self, guilds: List[discord.Guild]) -> bool:
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -360,11 +369,13 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def reset_weekly(self):
+    async def reset_weekly(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def add_weekly_pickems_credits(self, guild: discord.Guild, top_members: List[int]):
+    async def add_weekly_pickems_credits(
+        self, guild: discord.Guild, top_members: List[int]
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -382,91 +393,109 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def delete_pickems_channels(self, channels: List[int]):
+    async def create_pickems_channels_and_message(
+        self, guilds: List[discord.Guild], day: datetime
+    ) -> Dict[int, List[int]]:
         raise NotImplementedError()
 
     @abstractmethod
-    async def tally_guild_leaderboard(self, guild: discord.Guild):
+    async def create_weekly_pickems_pages(self, guilds: List[discord.Guild]) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def tally_leaderboard(self):
+    async def delete_pickems_channels(self, channels: List[int]) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_commands(self, ctx: commands.Context):
+    async def tally_guild_leaderboard(self, guild: discord.Guild) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_settings(self, ctx: commands.Context):
+    async def tally_leaderboard(self) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_credits(self, ctx: commands.Context):
+    async def pickems_commands(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_credits_base(self, ctx: commands.Context, credits: Optional[int] = None):
+    async def pickems_settings(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_credits_top(self, ctx: commands.Context, credits: Optional[int] = None):
+    async def pickems_credits(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_credits_amount(self, ctx: commands.Context, amount: Optional[int] = None):
+    async def pickems_credits_base(
+        self, ctx: commands.Context, credits: Optional[int] = None
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def set_pickems_message(self, ctx: commands.Context, *, message: Optional[str] = ""):
+    async def pickems_credits_top(
+        self, ctx: commands.Context, credits: Optional[int] = None
+    ) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_credits_amount(
+        self, ctx: commands.Context, amount: Optional[int] = None
+    ) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_pickems_message(
+        self, ctx: commands.Context, *, message: Optional[str] = ""
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def set_pickems_timezone(
         self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
     async def setup_auto_pickems(
         self, ctx: commands.Context, category: Optional[discord.CategoryChannel] = None
-    ):
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def delete_auto_pickems(self, ctx: commands.Context):
+    async def delete_auto_pickems(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def toggle_auto_pickems(self, ctx: commands.Context):
+    async def toggle_auto_pickems(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_page(self, ctx, date: Optional[str] = None):
+    async def pickems_page(self, ctx, date: Optional[str] = None) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def rempickem(self, ctx: commands.Context, true_or_false: bool):
+    async def rempickem(self, ctx: commands.Context, true_or_false: bool) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_leaderboard_commands(self, ctx: commands.Context):
+    async def pickems_leaderboard_commands(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool) -> None:
         raise NotImplementedError()
 
     #######################################################################
@@ -474,73 +503,75 @@ class MixinMeta(ABC):
     #######################################################################
 
     @abstractmethod
-    async def hockeydev(self, ctx: commands.Context):
+    async def hockeydev(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def reset_weekly_pickems_data(self, ctx: commands.Context):
+    async def reset_weekly_pickems_data(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def getgoals(self, ctx: commands.Context):
+    async def getgoals(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def pickems_tally(self, ctx: commands.Context):
+    async def pickems_tally(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def remove_old_pickems(self, ctx: commands.Context, year: int, month: int, day: int):
+    async def remove_old_pickems(
+        self, ctx: commands.Context, year: int, month: int, day: int
+    ) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def check_pickem_winner(self, ctx: commands.Context, days: int = 1):
+    async def check_pickem_winner(self, ctx: commands.Context, days: int = 1) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def fix_all_pickems(self, ctx: commands.Context):
+    async def fix_all_pickems(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def teststandings(self, ctx: commands.Context):
+    async def teststandings(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def cogstats(self, ctx: commands.Context):
+    async def cogstats(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def customemoji(self, ctx: commands.Context):
+    async def customemoji(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def resetgames(self, ctx: commands.Context):
+    async def resetgames(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def setcreated(self, ctx: commands.Context, created: bool):
+    async def setcreated(self, ctx: commands.Context, created: bool) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def cleargdc(self, ctx: commands.Context):
+    async def cleargdc(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def clear_broken_channels(self, ctx: commands.Context):
+    async def clear_broken_channels(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def remove_broken_guild(self, ctx: commands.Context):
+    async def remove_broken_guild(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def lights(self, ctx: commands.Context):
+    async def lights(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def testloop(self, ctx: commands.Context):
+    async def testloop(self, ctx: commands.Context) -> None:
         raise NotImplementedError()
 
     @abstractmethod
-    async def clear_seasonal_leaderboard_all(self, ctx: commands.Context):
+    async def clear_seasonal_leaderboard_all(self, ctx: commands.Context) -> None:
         raise NotImplementedError()

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -202,7 +202,9 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def set_hockey_timezone(self, ctx: commands.Context, timezone: TimezoneFinder = None):
+    async def set_hockey_timezone(
+        self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
+    ):
         raise NotImplementedError()
 
     @abstractmethod
@@ -399,7 +401,9 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def set_pickems_timezone(self, ctx: commands.Context, timezone: TimezoneFinder = None):
+    async def set_pickems_timezone(
+        self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
+    ):
         raise NotImplementedError()
 
     @abstractmethod

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -1,0 +1,481 @@
+import asyncio
+from abc import ABC, abstractmethod
+from typing import List, Literal, Optional
+
+import aiohttp
+import discord
+from redbot.core import Config, commands
+from redbot.core.bot import Red
+
+from .game import Game
+from .helper import HockeyStandings, HockeyStates, HockeyTeams, TeamDateFinder, YearFinder
+from .pickems import Pickems
+
+
+class MixinMeta(ABC):
+    """
+    Base class for well behaved type hint detection with composite class.
+
+    Basically, to keep developers sane when not all attributes are defined in each mixin.
+    """
+
+    def __init__(self, *_args):
+        self.config: Config
+        self.bot: Red
+        self.TEST_LOOP: bool
+        self.all_pickems: dict
+        self.session: aiohttp.ClientSession
+        self.pickems_config: Config
+        self._ready: asyncio.Event
+
+    #######################################################################
+    # hockey_commands.py                                                  #
+    #######################################################################
+
+    @abstractmethod
+    async def hockey_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def version(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def hockeyhub(self, ctx: commands.Context, *, search: str):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def team_role(self, ctx: commands.Context, *, team: HockeyTeams):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def team_goals(self, ctx: commands.Context, *, team: HockeyTeams = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def games(self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def schedule(
+        self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def player_id_lookup(self, name: str):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def player(
+        self,
+        ctx: commands.Context,
+        *,
+        search: str,
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def roster(
+        self, ctx: commands.Context, season: Optional[YearFinder] = None, *, search: HockeyTeams
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def rules(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def post_leaderboard(
+        self, ctx: commands.Context, leaderboard_type: Literal["season", "weekly", "worst"]
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def leaderboard(self, ctx: commands.Context, leaderboard_type: str = "seasonal"):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def otherdiscords(self, ctx: commands.Context, team: HockeyTeams):
+        raise NotImplementedError()
+
+    #######################################################################
+    # gamedaychannels.py                                                  #
+    #######################################################################
+
+    @abstractmethod
+    async def gdc(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_settings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_delete(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_default_game_state(self, ctx: commands.Context, *state: HockeyStates):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_create(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_toggle(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_category(self, ctx: commands.Context, category: discord.CategoryChannel):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_autodelete(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def test_gdc(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def gdc_setup(
+        self,
+        ctx: commands.Context,
+        team: HockeyTeams,
+        category: discord.CategoryChannel = None,
+        delete_gdc: bool = True,
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_chn_name(self, game: Game):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def check_new_gdc(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_gdc(self, guild: discord.Guild, game_data: Optional[Game] = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_gdc(self, guild: discord.Guild):
+        raise NotImplementedError()
+
+    #######################################################################
+    # hockeyset.py                                                        #
+    #######################################################################
+
+    @abstractmethod
+    async def hockeyset_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def hockey_settings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def reset(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def leaderboardset(
+        self,
+        ctx: commands.Context,
+        user: discord.Member,
+        season: int,
+        weekly: int = None,
+        total: int = None,
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def check_notification_settings(self, guild: discord.Guild) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def hockey_notifications(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_goal_notification_style(
+        self, ctx: commands.Context, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_ot_notification_style(
+        self, ctx: commands.Context, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_so_notification_style(
+        self, ctx: commands.Context, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_game_start_notification_style(
+        self, ctx: commands.Context, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_channel_goal_notification_style(
+        self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_channel_game_start_notification_style(
+        self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def post_standings(
+        self,
+        ctx: commands.Context,
+        standings_type: str,
+        channel: Optional[discord.TextChannel] = None,
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def togglestandings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_game_state_updates(
+        self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_game_publish_updates(
+        self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def add_goals(
+        self, ctx: commands.Context, team: HockeyTeams, channel: Optional[discord.TextChannel]
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_goals(
+        self,
+        ctx: commands.Context,
+        team: Optional[HockeyTeams] = None,
+        channel: Optional[discord.TextChannel] = None,
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def setup_auto_pickems(
+        self, ctx: commands.Context, category: Optional[discord.CategoryChannel] = None
+    ):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_auto_pickems(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def toggle_auto_pickems(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_page(self, ctx, date: Optional[str] = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def rempickem(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_leaderboard_commands(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        raise NotImplementedError()
+
+    #######################################################################
+    # pickems.py                                                          #
+    #######################################################################
+
+    @abstractmethod
+    async def pickems_loop(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def save_pickems_data(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def after_pickems_loop(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def before_pickems_loop(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def pickems_name(self, game: Game) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def find_pickems_object(self, game: Game) -> List[Pickems]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def set_guild_pickem_winner(self, game: Game):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_weekly_pickems_pages(
+        self, guilds: List[discord.Guild], game_obj: Game
+    ) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_pickem_object(
+        self,
+        guild: discord.Guild,
+        message: discord.Message,
+        channel: discord.TextChannel,
+        game: Game,
+    ) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def reset_weekly(self):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_pickems_channel(
+        self, name: str, guild: discord.Guild
+    ) -> Optional[discord.TextChannel]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def create_pickems_game_msg(self, channel: discord.TextChannel, game: Game):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def delete_pickems_channels(self, channels: List[int]):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def tally_guild_leaderboard(self, guild: discord.Guild):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def tally_leaderboard(self):
+        raise NotImplementedError()
+
+    #######################################################################
+    # dev.py                                                              #
+    #######################################################################
+
+    @abstractmethod
+    async def hockeydev(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def reset_weekly_pickems_data(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def getgoals(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_tally(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_old_pickems(self, ctx: commands.Context, year: int, month: int, day: int):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def check_pickem_winner(self, ctx: commands.Context, days: int = 1):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def fix_all_pickems(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def teststandings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def cogstats(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def customemoji(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def resetgames(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def setcreated(self, ctx: commands.Context, created: bool):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def cleargdc(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_broken_channels(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_broken_guild(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def lights(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def testloop(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def clear_seasonal_leaderboard_all(self, ctx: commands.Context):
+        raise NotImplementedError()

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -202,10 +202,6 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def reset(self, ctx: commands.Context) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
     async def set_hockey_timezone(
         self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
     ) -> None:

--- a/hockey/abc.py
+++ b/hockey/abc.py
@@ -29,6 +29,7 @@ class MixinMeta(ABC):
     def __init__(self, *_args):
         self.config: Config
         self.bot: Red
+        self.loop: Optional[asyncio.Task]
         self.TEST_LOOP: bool
         self.all_pickems: dict
         self.session: aiohttp.ClientSession
@@ -363,6 +364,10 @@ class MixinMeta(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    async def add_weekly_pickems_credits(self, guild: discord.Guild, top_members: List[int]):
+        raise NotImplementedError()
+
+    @abstractmethod
     async def create_pickems_channel(
         self, name: str, guild: discord.Guild
     ) -> Optional[discord.TextChannel]:
@@ -394,6 +399,22 @@ class MixinMeta(ABC):
 
     @abstractmethod
     async def pickems_settings(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_credits(self, ctx: commands.Context):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_credits_base(self, ctx: commands.Context, credits: Optional[int] = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_credits_top(self, ctx: commands.Context, credits: Optional[int] = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def pickems_credits_amount(self, ctx: commands.Context, amount: Optional[int] = None):
         raise NotImplementedError()
 
     @abstractmethod

--- a/hockey/dev.py
+++ b/hockey/dev.py
@@ -63,7 +63,7 @@ class HockeyDev(MixinMeta):
                 continue
             if await self.pickems_config.guild(guild).pickems_category():
                 guilds_to_make_new_pickems.append(guild)
-        await self.create_weekly_pickems_pages(guilds_to_make_new_pickems, Game)
+        await self.create_weekly_pickems_pages(guilds_to_make_new_pickems)
         await ctx.send("Finished resetting all pickems data.")
 
     @hockeydev.command(name="pickemsannounce")

--- a/hockey/dev.py
+++ b/hockey/dev.py
@@ -76,7 +76,7 @@ class HockeyDev(MixinMeta):
         """
         all_guilds = await self.pickems_config.all_guilds()
         for guild_id, data in all_guilds.items():
-            g = bot.get_guild(guild_id)
+            g = self.bot.get_guild(guild_id)
             if g is None:
                 continue
             if data["pickems_channels"]:
@@ -84,7 +84,7 @@ class HockeyDev(MixinMeta):
                     chan = g.get_channel(channel_id)
                     if chan:
                         try:
-                            await chan.send(msg)
+                            await chan.send(message)
                         except Exception:
                             pass
         await ctx.send(_("Message announced in pickems channels."))
@@ -122,11 +122,19 @@ class HockeyDev(MixinMeta):
         """
         Manually tally the leaderboard for all servers
         """
-        await self.tally_leaderboard()
+        try:
+            await self.tally_leaderboard()
+        except Exception:
+            log.exception("Error manually tallying pickems Leaderboard.")
+            return await ctx.send(
+                _("There was an error tallying pickems leaerboard. Check the console fore errors.")
+            )
         await ctx.send(_("Leaderboard tallying complete."))
 
     @hockeydev.command(name="removeoldpickems")
-    async def remove_old_pickems(self, ctx: commands.Context, year: int, month: int, day: int) -> None:
+    async def remove_old_pickems(
+        self, ctx: commands.Context, year: int, month: int, day: int
+    ) -> None:
         """
         Remove pickems objects created before a specified date.
         """

--- a/hockey/dev.py
+++ b/hockey/dev.py
@@ -41,7 +41,7 @@ class HockeyDev(MixinMeta):
 
     @commands.group(aliases=["nhldev"])
     @commands.is_owner()
-    async def hockeydev(self, ctx: commands.Context):
+    async def hockeydev(self, ctx: commands.Context) -> None:
         """
         Secret dev only commands for Hockey
 
@@ -51,7 +51,7 @@ class HockeyDev(MixinMeta):
         pass
 
     @hockeydev.command(name="resetpickemsweekly")
-    async def reset_weekly_pickems_data(self, ctx: commands.Context):
+    async def reset_weekly_pickems_data(self, ctx: commands.Context) -> None:
         """
         Force reset all pickems data for the week
         """
@@ -67,7 +67,7 @@ class HockeyDev(MixinMeta):
         await ctx.send("Finished resetting all pickems data.")
 
     @hockeydev.command(name="pickemsannounce")
-    async def announce_pickems(self, ctx: commands.Context, *, message: str):
+    async def announce_pickems(self, ctx: commands.Context, *, message: str) -> None:
         """
         Announce a message in all setup pickems channels
 
@@ -90,7 +90,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Message announced in pickems channels."))
 
     @hockeydev.command()
-    async def getgoals(self, ctx: commands.Context):
+    async def getgoals(self, ctx: commands.Context) -> None:
         """
         Testing function with testgame.json
         """
@@ -118,7 +118,7 @@ class HockeyDev(MixinMeta):
         await ctx.send("Done testing.")
 
     @hockeydev.command(name="pickemstally")
-    async def pickems_tally(self, ctx: commands.Context):
+    async def pickems_tally(self, ctx: commands.Context) -> None:
         """
         Manually tally the leaderboard for all servers
         """
@@ -126,7 +126,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Leaderboard tallying complete."))
 
     @hockeydev.command(name="removeoldpickems")
-    async def remove_old_pickems(self, ctx: commands.Context, year: int, month: int, day: int):
+    async def remove_old_pickems(self, ctx: commands.Context, year: int, month: int, day: int) -> None:
         """
         Remove pickems objects created before a specified date.
         """
@@ -142,7 +142,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("All old pickems objects deleted."))
 
     @hockeydev.command(name="checkpickemswinner")
-    async def check_pickem_winner(self, ctx: commands.Context, days: int = 1):
+    async def check_pickem_winner(self, ctx: commands.Context, days: int = 1) -> None:
         """
         Manually check all pickems objects for winners
 
@@ -159,7 +159,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Pickems winners set."))
 
     @hockeydev.command(name="fixallpickems")
-    async def fix_all_pickems(self, ctx: commands.Context):
+    async def fix_all_pickems(self, ctx: commands.Context) -> None:
         """
         Fixes winner on all current pickems objects if possible
         """
@@ -174,7 +174,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("All pickems winners set."))
 
     @hockeydev.command()
-    async def teststandings(self, ctx: commands.Context):
+    async def teststandings(self, ctx: commands.Context) -> None:
         """
         Test the automatic standings function/manually update standings
         """
@@ -186,7 +186,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Finished fixing all standings messages."))
 
     @hockeydev.command()
-    async def cogstats(self, ctx: commands.Context):
+    async def cogstats(self, ctx: commands.Context) -> None:
         """
         Display current number of servers and channels
         the cog is storing in console
@@ -274,7 +274,7 @@ class HockeyDev(MixinMeta):
             await ctx.maybe_send_embed(page)
 
     @hockeydev.command()
-    async def customemoji(self, ctx: commands.Context):
+    async def customemoji(self, ctx: commands.Context) -> None:
         """
         Set custom emojis for the bot to use
 
@@ -311,7 +311,7 @@ class HockeyDev(MixinMeta):
         await ctx.send("You should reload the cog for everything to work correctly.")
 
     @hockeydev.command()
-    async def resetgames(self, ctx: commands.Context):
+    async def resetgames(self, ctx: commands.Context) -> None:
         """
         Resets the bots game data incase something goes wrong
         """
@@ -328,7 +328,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Saved game data reset."))
 
     @hockeydev.command()
-    async def setcreated(self, ctx: commands.Context, created: bool):
+    async def setcreated(self, ctx: commands.Context, created: bool) -> None:
         """
         Sets whether or not the game day channels have been created
         """
@@ -336,7 +336,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("created_gdc set to ") + str(created))
 
     @hockeydev.command()
-    async def cleargdc(self, ctx: commands.Context):
+    async def cleargdc(self, ctx: commands.Context) -> None:
         """
         Checks for manually deleted channels from the GDC channel list
         and removes them
@@ -355,7 +355,7 @@ class HockeyDev(MixinMeta):
         await ctx.tick()
 
     @hockeydev.command(name="clearbrokenchannels")
-    async def clear_broken_channels(self, ctx: commands.Context):
+    async def clear_broken_channels(self, ctx: commands.Context) -> None:
         """
         Removes missing channels from the config
         """
@@ -383,7 +383,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Broken channels removed"))
 
     @hockeydev.command()
-    async def remove_broken_guild(self, ctx: commands.Context):
+    async def remove_broken_guild(self, ctx: commands.Context) -> None:
         """
         Removes a server that no longer exists on the bot
         """
@@ -399,7 +399,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Saved servers the bot is no longer on have been removed."))
 
     @hockeydev.command(hidden=True)
-    async def lights(self, ctx: commands.Context):
+    async def lights(self, ctx: commands.Context) -> None:
         """
         Tests the philips Hue light integration
         This is hard coded at the moment with no plans to make work generally
@@ -412,7 +412,7 @@ class HockeyDev(MixinMeta):
         await ctx.tick()
 
     @hockeydev.command(hidden=True)
-    async def testloop(self, ctx: commands.Context):
+    async def testloop(self, ctx: commands.Context) -> None:
         """
         Toggle the test game loop
         """
@@ -420,7 +420,7 @@ class HockeyDev(MixinMeta):
         await ctx.send(_("Test loop set to ") + str(self.TEST_LOOP))
 
     @hockeydev.command()
-    async def clear_seasonal_leaderboard_all(self, ctx: commands.Context):
+    async def clear_seasonal_leaderboard_all(self, ctx: commands.Context) -> None:
         """
         Clears the bots seasonal pickems leaderboard
         """

--- a/hockey/game.py
+++ b/hockey/game.py
@@ -606,7 +606,6 @@ class Game:
         config = bot.get_cog("Hockey").config
         guild_settings = await config.guild(guild).all()
         channel_settings = await config.channel(channel).all()
-        del guild_settings["pickems"]  # No need to keep this in memory twice
         game_day_channels = guild_settings["gdc"]
         can_embed = channel.permissions_for(guild.me).embed_links
         publish_states = []  # await config.channel(channel).publish_states()

--- a/hockey/game.py
+++ b/hockey/game.py
@@ -295,7 +295,7 @@ class Game:
                     for goal in list_goals[ordinal]:
                         if count == 4:
                             em.add_field(
-                                name=str(ordinal) + _(" Period Goals"),
+                                name=_("{ordinal} Period Goals").format(ordinal=ordinal),
                                 value=goal_msg[:1024],
                                 inline=False,
                             )
@@ -306,25 +306,38 @@ class Game:
                         except KeyError:
                             emoji = ""
                         if not goal.link:
-                            goal_msg += f"{emoji} {goal.team_name} Goal By {goal.description}\n\n"
+                            goal_msg += _("{emoji} {team} Goal By {description}\n\n").format(
+                                emoji=emoji, team=goal.team_name, description=goal.description
+                            )
                         else:
-                            goal_msg += f"{emoji} [{goal.team_name} Goal By {goal.description}]({goal.link})\n\n"
+                            goal_msg += _(
+                                "{emoji} [{team} Goal By {description}]({link})\n\n"
+                            ).format(
+                                emoji=emoji,
+                                team=goal.team_name,
+                                description=goal.description,
+                                link=goal.link,
+                            )
                         count += 1
                     if len(list_goals[ordinal]) > 4 and goal_msg != "":
                         em.add_field(
-                            name=str(ordinal) + _(" Period Goals (Continued)"),
+                            name=_("{ordinal} Period Goals (Continued)").format(ordinal=ordinal),
                             value=goal_msg[:1024],
                         )
                     if len(list_goals[ordinal]) <= 4 and goal_msg != "":
                         em.add_field(
-                            name=str(ordinal) + _(" Period Goals"),
+                            name=_("{ordinal} Period Goals").format(ordinal=ordinal),
                             value=goal_msg[:1024],
                             inline=False,
                         )
                 if len(so_goals) != 0:
                     home_msg, away_msg = await self.goals[0].get_shootout_display(self)
-                    em.add_field(name=f"{self.home_team}" + _(" Shootout"), value=home_msg)
-                    em.add_field(name=f"{self.away_team}" + _(" Shootout"), value=away_msg)
+                    em.add_field(
+                        name=_("{team} Shootout").format(team=self.home_team), value=home_msg
+                    )
+                    em.add_field(
+                        name=+_("{team} Shootout").format(team=self.away_team), value=away_msg
+                    )
             if self.first_star is not None:
                 stars = f"⭐ {self.first_star}\n⭐⭐ {self.second_star}\n⭐⭐⭐ {self.third_star}"
                 em.add_field(name=_("Stars of the game"), value=stars, inline=False)
@@ -550,11 +563,7 @@ class Game:
         Posts the period recap in designated channels
         """
         if not channel.permissions_for(channel.guild.me).send_messages:
-            log.debug(
-                _("No permission to send messages in {channel} ({id})").format(
-                    channel=channel, id=channel.id
-                )
-            )
+            log.debug(f"No permission to send messages in {repr(channel)}")
             return
         try:
             msg = await channel.send(embed=embed)
@@ -562,12 +571,7 @@ class Game:
                 pass
                 # await msg.publish()
         except Exception:
-            log.error(
-                _("Could not post goal in {channel} ({id})").format(
-                    channel=channel, id=channel.id
-                ),
-                exc_info=True,
-            )
+            log.exception(f"Could not post goal in {repr(channel)}")
 
     async def post_game_state(self, bot):
         """
@@ -597,11 +601,7 @@ class Game:
     async def actually_post_state(self, bot, channel, state_embed, state_text):
         guild = channel.guild
         if not channel.permissions_for(guild.me).send_messages:
-            log.debug(
-                _("No permission to send messages in {channel} ({id})").format(
-                    channel=channel, id=channel.id
-                )
-            )
+            log.debug(f"No permission to send messages in {repr(channel)}")
             return
         config = bot.get_cog("Hockey").config
         guild_settings = await config.guild(guild).all()
@@ -666,12 +666,7 @@ class Game:
                     except Exception:
                         pass
             except Exception:
-                log.error(
-                    _("Could not post goal in {channel} ({id})").format(
-                        channel=channel, id=channel.id
-                    ),
-                    exc_info=True,
-                )
+                log.exception(f"Could not post goal in {repr(channel)}")
 
         else:
             if self.game_state == "Preview":
@@ -704,12 +699,7 @@ class Game:
                             log.debug("Could not add reactions")
                         return channel, preview_msg
             except Exception:
-                log.error(
-                    _("Could not post goal in {channel} ({id})").format(
-                        channel=channel, id=channel.id
-                    ),
-                    exc_info=True,
-                )
+                log.exception(f"Could not post goal in {repr(channel)}")
 
     async def check_team_goals(self, bot):
         """

--- a/hockey/game.py
+++ b/hockey/game.py
@@ -181,7 +181,7 @@ class Game:
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         session: Optional[aiohttp.ClientSession] = None,
-    ) -> List[str]:
+    ) -> List[dict]:
         """
         Get a specified days games, defaults to the current day
         requires a datetime object
@@ -730,6 +730,8 @@ class Game:
             if goal.goal_id not in team_data[goal.team_name]["goal_id"]:
                 # attempts to post the goal if there is a new goal
                 bot.dispatch("hockey_goal", self, goal)
+                goal.home_shots = self.home_shots
+                goal.away_shots = self.away_shots
                 msg_list = await goal.post_team_goal(bot, self)
                 team_list.remove(team_data[goal.team_name])
                 team_data[goal.team_name]["goal_id"][goal.goal_id] = {
@@ -743,6 +745,10 @@ class Game:
                 # attempts to edit the goal if the scorers have changed
                 old_goal = Goal(**team_data[goal.team_name]["goal_id"][goal.goal_id]["goal"])
                 if goal.description != old_goal.description or goal.link != old_goal.link:
+                    goal.home_shots = old_goal.home_shots
+                    goal.away_shots = old_goal.away_shots
+                    # This is to keep shots consistent between edits
+                    # Shots should not update as the game continues
                     bot.dispatch("hockey_goal_edit", self, goal)
                     old_msgs = team_data[goal.team_name]["goal_id"][goal.goal_id]["messages"]
                     team_list.remove(team_data[goal.team_name])

--- a/hockey/game.py
+++ b/hockey/game.py
@@ -162,8 +162,8 @@ class Game:
             for games in games_list:
                 try:
                     if session is None:
-                        async with aiohttp.ClientSession() as session:
-                            async with session.get(BASE_URL + games["link"]) as resp:
+                        async with aiohttp.ClientSession() as new_session:
+                            async with new_session.get(BASE_URL + games["link"]) as resp:
                                 data = await resp.json()
                     else:
                         async with session.get(BASE_URL + games["link"]) as resp:
@@ -210,8 +210,8 @@ class Game:
             # if a team is provided get just that TEAMS data
             url += "&teamId={}".format(TEAMS[team]["id"])
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(url) as resp:
                     data = await resp.json()
         else:
             async with session.get(url) as resp:

--- a/hockey/gamedaychannels.py
+++ b/hockey/gamedaychannels.py
@@ -309,10 +309,14 @@ class GameDayChannels(MixinMeta):
             # Return none if there's no category to create the channel
             return
         if not category.permissions_for(guild.me).manage_channels:
-            log.info(f"Cannot create new GDC in {repr(guild)} due to too many missing permissions.")
+            log.info(
+                f"Cannot create new GDC in {repr(guild)} due to too many missing permissions."
+            )
             return
         if len(category.channels) >= 50:
-            log.info(f"Cannot create new GDC in {repr(guild)} due to too many channels in category.")
+            log.info(
+                f"Cannot create new GDC in {repr(guild)} due to too many channels in category."
+            )
             return
         if game_data is None:
             team = await self.config.guild(guild).gdc_team()
@@ -351,7 +355,7 @@ class GameDayChannels(MixinMeta):
         # guild_team = await config.guild(guild).gdc_team()
         channel_team = team if team != "all" else next_game.home_team
         timezone = (
-            TEAMS[channel_team]["timezone"]
+            await self.config.guild(guild).timezone() or TEAMS[channel_team]["timezone"]
             if channel_team in TEAMS
             else TEAMS[next_game.away_team]["timezone"]
         )

--- a/hockey/gamedaychannels.py
+++ b/hockey/gamedaychannels.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import discord
 from redbot.core import commands
-from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list
 from redbot.core.utils.menus import start_adding_reactions
@@ -31,7 +30,7 @@ class GameDayChannels(MixinMeta):
     @commands.group()
     @commands.mod_or_permissions(manage_channels=True)
     @commands.guild_only()
-    async def gdc(self, ctx: commands.Context):
+    async def gdc(self, ctx: commands.Context) -> None:
         """
         Game Day Channel setup for the server
 
@@ -41,7 +40,7 @@ class GameDayChannels(MixinMeta):
         """
 
     @gdc.command(name="settings")
-    async def gdc_settings(self, ctx: commands.Context):
+    async def gdc_settings(self, ctx: commands.Context) -> None:
         """
         Show the current Game Day Channel Settings
         """
@@ -99,7 +98,7 @@ class GameDayChannels(MixinMeta):
                 await ctx.send(embed=em)
 
     @gdc.command(name="delete")
-    async def gdc_delete(self, ctx: commands.Context):
+    async def gdc_delete(self, ctx: commands.Context) -> None:
         """
         Delete all current game day channels for the server
         """
@@ -107,7 +106,7 @@ class GameDayChannels(MixinMeta):
         await ctx.send(_("Game day channels deleted."))
 
     @gdc.command(name="defaultstate")
-    async def gdc_default_game_state(self, ctx: commands.Context, *state: HockeyStates):
+    async def gdc_default_game_state(self, ctx: commands.Context, *state: HockeyStates) -> None:
         """
         Set the default game state updates for Game Day Channels.
 
@@ -129,7 +128,7 @@ class GameDayChannels(MixinMeta):
             await ctx.send(_("GDC game updates not set"))
 
     @gdc.command(name="create")
-    async def gdc_create(self, ctx: commands.Context):
+    async def gdc_create(self, ctx: commands.Context) -> None:
         """
         Creates the next gdc for the server
         """
@@ -146,7 +145,7 @@ class GameDayChannels(MixinMeta):
         await ctx.send(_("Game day channels created."))
 
     @gdc.command(name="toggle")
-    async def gdc_toggle(self, ctx: commands.Context):
+    async def gdc_toggle(self, ctx: commands.Context) -> None:
         """
         Toggles the game day channel creation on this server
         """
@@ -158,7 +157,7 @@ class GameDayChannels(MixinMeta):
         await ctx.send(msg)
 
     @gdc.command(name="category")
-    async def gdc_category(self, ctx: commands.Context, category: discord.CategoryChannel):
+    async def gdc_category(self, ctx: commands.Context, category: discord.CategoryChannel) -> None:
         """
         Change the category for channel creation. Channel is case sensitive.
         """
@@ -171,7 +170,7 @@ class GameDayChannels(MixinMeta):
         await ctx.send(msg + category.name)
 
     @gdc.command(name="autodelete")
-    async def gdc_autodelete(self, ctx: commands.Context):
+    async def gdc_autodelete(self, ctx: commands.Context) -> None:
         """
         Toggle's auto deletion of game day channels.
         """
@@ -188,7 +187,7 @@ class GameDayChannels(MixinMeta):
 
     @gdc.command(name="test")
     @commands.is_owner()
-    async def test_gdc(self, ctx: commands.Context):
+    async def test_gdc(self, ctx: commands.Context) -> None:
         """
         Test checking for new game day channels
         """
@@ -203,7 +202,7 @@ class GameDayChannels(MixinMeta):
         team: HockeyTeams,
         category: discord.CategoryChannel = None,
         delete_gdc: bool = True,
-    ):
+    ) -> None:
         """
         Setup game day channels for a single team or all teams
 
@@ -245,7 +244,7 @@ class GameDayChannels(MixinMeta):
     # GDC logic                                                           #
     #######################################################################
 
-    async def get_chn_name(self, game: Game):
+    async def get_chn_name(self, game: Game) -> str:
         """
         Creates game day channel name
         """
@@ -255,7 +254,7 @@ class GameDayChannels(MixinMeta):
         )
         return chn_name.lower()
 
-    async def check_new_gdc(self):
+    async def check_new_gdc(self) -> None:
         game_list = await Game.get_games(
             session=self.session
         )  # Do this once so we don't spam the api
@@ -295,7 +294,7 @@ class GameDayChannels(MixinMeta):
                 for game in game_list:
                     await self.create_gdc(guild, game)
 
-    async def create_gdc(self, guild: discord.Guild, game_data: Optional[Game] = None):
+    async def create_gdc(self, guild: discord.Guild, game_data: Optional[Game] = None) -> None:
         """
         Creates a game day channel for the given game object
         if no game object is passed it looks for the set team for the guild
@@ -397,7 +396,7 @@ class GameDayChannels(MixinMeta):
                 preview_msg, [next_game.away_emoji[2:-1], next_game.home_emoji[2:-1]]
             )
 
-    async def delete_gdc(self, guild: discord.Guild):
+    async def delete_gdc(self, guild: discord.Guild) -> None:
         """
         Deletes all game day channels in a given guild
         """

--- a/hockey/gamedaychannels.py
+++ b/hockey/gamedaychannels.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 from redbot.core.bot import Red
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list
@@ -29,7 +29,7 @@ class GameDayChannels(MixinMeta):
     #######################################################################
 
     @commands.group()
-    @checks.mod_or_permissions(manage_channels=True)
+    @commands.mod_or_permissions(manage_channels=True)
     @commands.guild_only()
     async def gdc(self, ctx: commands.Context):
         """

--- a/hockey/goal.py
+++ b/hockey/goal.py
@@ -5,13 +5,12 @@ from typing import List, Optional, Tuple
 
 import discord
 from redbot import VersionInfo, version_info
-from redbot.core import Config
 from redbot.core.bot import Red
-from redbot.core.utils import bounded_gather, AsyncIter
 from redbot.core.i18n import Translator
+from redbot.core.utils import AsyncIter, bounded_gather
 
 from .constants import HEADSHOT_URL, TEAMS
-from .helper import check_to_post, get_team, get_channel_obj
+from .helper import check_to_post, get_channel_obj, get_team
 
 try:
     from .oilers import Oilers

--- a/hockey/goal.py
+++ b/hockey/goal.py
@@ -65,6 +65,8 @@ class Goal:
         self.event = kwargs.get("event")
         self.link = kwargs.get("link", None)
         self.tasks: List[asyncio.Task] = []
+        self.home_shots: int = 0
+        self.away_shots: int = 0
 
     def __repr__(self):
         return "<Hockey Goal team={0.team_name} id={0.goal_id} >".format(self)
@@ -86,6 +88,8 @@ class Goal:
             "empty_net": self.empty_net,
             "event": self.event,
             "link": self.link,
+            "home_shots": self.home_shots,
+            "away_shots": self.away_shots,
         }
 
     @classmethod
@@ -142,6 +146,8 @@ class Goal:
             empty_net=empty_net,
             event=data["result"]["event"],
             link=link,
+            home_shots=data.get("home_shots", 0),
+            away_shots=data.get("away_shots", 0),
         )
 
     async def post_team_goal(self, bot: Red, game_data: Game) -> List[Tuple[int, int, int]]:
@@ -426,10 +432,10 @@ class Goal:
                 em.colour = colour
             em.set_author(name=title, url=url, icon_url=logo)
             home_str = _("Goals: **{home_score}**\nShots: **{home_shots}**").format(
-                home_score=self.home_score, home_shots=game.home_shots
+                home_score=self.home_score, home_shots=self.home_shots
             )
             away_str = _("Goals: **{away_score}**\nShots: **{away_shots}**").format(
-                away_score=self.away_score, away_shots=game.away_shots
+                away_score=self.away_score, away_shots=self.away_shots
             )
             home_field = f"{game.home_emoji} {game.home_team} {game.home_emoji}"
             away_field = f"{game.away_emoji} {game.away_team} {game.away_emoji}"

--- a/hockey/helper.py
+++ b/hockey/helper.py
@@ -1,15 +1,14 @@
 import asyncio
-import discord
 import logging
 import re
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional, Pattern, Union, Tuple
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Pattern, Tuple, Union
 
-from redbot.core.bot import Red
-
+import discord
 import pytz
 from discord.ext.commands.converter import Converter  # type: ignore[import]
 from discord.ext.commands.errors import BadArgument  # type: ignore[import]
+from redbot.core.bot import Red
 from redbot.core.commands import Context
 from redbot.core.i18n import Translator
 
@@ -326,9 +325,7 @@ async def check_valid_team(team_name: str, standings: bool = False) -> List[str]
     return is_team
 
 
-async def get_channel_obj(
-    bot: Red, channel_id: int, data: dict
-) -> Optional[discord.TextChannel]:
+async def get_channel_obj(bot: Red, channel_id: int, data: dict) -> Optional[discord.TextChannel]:
     """
     Requires a bot object to access config, channel_id, and channel config data
     Returns the channel object and sets the guild ID if it's missing from config

--- a/hockey/helper.py
+++ b/hockey/helper.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional, Pattern, Tuple, Union
 
 import discord
 import pytz
-from discord.ext.commands.converter import Converter  # type: ignore[import]
-from discord.ext.commands.errors import BadArgument  # type: ignore[import]
+from discord.ext.commands.converter import Converter
+from discord.ext.commands.errors import BadArgument
 from redbot.core.bot import Red
 from redbot.core.commands import Context
 from redbot.core.i18n import Translator
@@ -30,7 +30,7 @@ YEAR_RE = re.compile(r"((19|20)\d\d)-?\/?((19|20)\d\d)?")
 TIMEZONE_RE = re.compile(r"|".join(re.escape(zone) for zone in pytz.common_timezones), flags=re.I)
 
 
-def utc_to_local(utc_dt, new_timezone="US/Pacific") -> datetime:
+def utc_to_local(utc_dt: datetime, new_timezone: str = "US/Pacific") -> datetime:
     eastern = pytz.timezone(new_timezone)
     return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=eastern)
 
@@ -213,12 +213,12 @@ class HockeyStandings(Converter):
     https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/cogs/mod/mod.py#L24
     """
 
-    async def convert(self, ctx: Context, argument: str) -> List[str]:
-        result = []
+    async def convert(self, ctx: Context, argument: str) -> Optional[str]:
+        result = None
         team_list = await check_valid_team(argument, True)
         if team_list == []:
             raise BadArgument('Standing or Team "{}" not found'.format(argument))
-        if len(team_list) == 1:
+        if len(team_list) >= 1:
             result = team_list[0]
         return result
 
@@ -254,9 +254,11 @@ async def check_to_post(
     return should_post
 
 
-async def get_team_role(
-    guild: discord.Guild, home_team: str, away_team: str
-) -> Tuple[Optional[discord.Role], Optional[discord.Role]]:
+async def get_team_role(guild: discord.Guild, home_team: str, away_team: str) -> Tuple[str, str]:
+    """
+    This returns the role mentions if they exist
+    Otherwise it returns the name of the team as a str
+    """
     home_role = None
     away_role = None
 
@@ -276,7 +278,7 @@ async def get_team_role(
     return home_role, away_role
 
 
-async def get_team(bot, team: str) -> TeamEntry:
+async def get_team(bot: Red, team: str) -> TeamEntry:
     config = bot.get_cog("Hockey").config
     team_list = await config.teams()
     if team_list is None:

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import aiohttp
 import yaml
@@ -108,8 +108,12 @@ class Hockey(
             pickems_category=None,
             pickems_message="",
             pickems_timezone="US/Pacific",
+            base_credits=0,
+            top_credits=0,
+            top_amount=0,
         )
-        self.loop = None
+        self.pickems_config.register_global(base_credits=0, top_credits=0, top_amount=0)
+        self.loop: Optional[asyncio.Task] = None
         self.TEST_LOOP = False
         # used to test a continuous loop of a single game data
         self.all_pickems = {}
@@ -166,22 +170,22 @@ class Hockey(
             log.info("Migrating old pickems to new file")
             all_guilds = await self.config.all_guilds()
             async for guild_id, data in AsyncIter(all_guilds.items(), steps=100):
-                if data["leaderboard"]:
+                if data.get("leaderboard"):
                     await self.pickems_config.guild_from_id(guild_id).leaderboard.set(
                         data["leaderboard"]
                     )
                     await self.config.guild_from_id(guild_id).leaderboard.clear()
                     log.info(f"Migrating leaderboard for {guild_id}")
-                if data["pickems"]:
+                if data.get("pickems"):
                     await self.config.guild_from_id(guild_id).pickems.clear()
                     log.info(f"Migrating pickems for {guild_id}")
-                if data["pickems_channels"]:
+                if data.get("pickems_channels"):
                     await self.pickems_config.guild_from_id(guild_id).pickems_channels.set(
                         data["pickems_channels"]
                     )
                     await self.config.guild_from_id(guild_id).pickems_channels.clear()
                     log.info(f"Migrating pickems channels for {guild_id}")
-                if data["pickems_category"]:
+                if data.get("pickems_category"):
                     await self.pickems_config.guild_from_id(guild_id).pickems_category.set(
                         data["pickems_category"]
                     )

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -319,7 +319,7 @@ class Hockey(
                             continue
                         if await self.config.guild(guild).pickems_category():
                             guilds_to_make_new_pickems.append(guild)
-                    await self.create_weekly_pickems_pages(guilds_to_make_new_pickems, Game)
+                    await self.create_weekly_pickems_pages(guilds_to_make_new_pickems)
 
                 except Exception:
                     log.error("Error creating new weekly pickems pages", exc_info=True)

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -75,10 +75,6 @@ class Hockey(
             "delete_gdc": True,
             "rules": "",
             "team_rules": "",
-            "pickems": {},
-            "leaderboard": {},
-            "pickems_category": None,
-            "pickems_channels": [],
             "game_state_notifications": False,
             "goal_notifications": False,
             "start_notifications": False,
@@ -177,7 +173,6 @@ class Hockey(
                     await self.config.guild_from_id(guild_id).leaderboard.clear()
                     log.info(f"Migrating leaderboard for {guild_id}")
                 if data["pickems"]:
-                    await self.pickems_config.guild_from_id(guild_id).pickems.set(data["pickems"])
                     await self.config.guild_from_id(guild_id).pickems.clear()
                     log.info(f"Migrating pickems for {guild_id}")
                 if data["pickems_channels"]:
@@ -207,6 +202,7 @@ class Hockey(
         then passes off to other functions as necessary
         """
         await self.bot.wait_until_red_ready()
+        await self._ready.wait()
         while True:
             try:
                 async with self.session.get(f"{BASE_URL}/api/v1/schedule") as resp:

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -270,7 +270,7 @@ class Hockey(
                         try:
                             await self.set_guild_pickem_winner(game)
                         except Exception:
-                            log.error("Pickems Set Winner error: ", exc_info=True)
+                            log.exception("Pickems Set Winner error: ")
                         self.current_games[link]["count"] += 1
                         if posted_final:
                             self.current_games[link]["count"] = 10

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -56,6 +56,7 @@ class Hockey(
     __author__ = ["TrustyJAID"]
 
     def __init__(self, bot):
+        super().__init__(self)
         self.bot = bot
         default_global = {"teams": [], "created_gdc": False, "print": False}
         for team in TEAMS:
@@ -124,11 +125,7 @@ class Hockey(
         self._ready: asyncio.Event = asyncio.Event()
         # self._ready is used to prevent pickems from opening
         # data from the wrong file location
-        self.pickems_games: Dict[str, Game] = {}
-        # This is a temporary class attr used for
-        # storing only 1 copy of the game object so
-        # we're not spamming the API with the same game over and over
-        # this gets cleared and is only used with leaderboard tallying
+
 
     def format_help_for_context(self, ctx: commands.Context) -> str:
         """

--- a/hockey/hockey.py
+++ b/hockey/hockey.py
@@ -1,14 +1,14 @@
 import asyncio
+import discord
 import json
 import logging
 from abc import ABC
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Optional, Dict
+from typing import Literal, Optional, Dict, List
 
 import aiohttp
 import yaml
-from redbot import version_info
 from redbot.core import Config, commands
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils import AsyncIter
@@ -160,7 +160,7 @@ class Hockey(
                 del data["leaderboard"][str(user_id)]
                 await self.config.guild_from_id(g_id).leaderboard.set(data["leaderboard"])
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         if 218773382617890828 in self.bot.owner_ids:
             try:
                 self.bot.add_dev_env_value("hockey", lambda x: self)
@@ -169,7 +169,7 @@ class Hockey(
         self.loop = asyncio.create_task(self.game_check_loop())
         await self.migrate_settings()
 
-    async def migrate_settings(self):
+    async def migrate_settings(self) -> None:
         schema_version = await self.config.schema_version()
         if schema_version == 0:
             log.info("Migrating old pickems to new file")
@@ -206,7 +206,7 @@ class Hockey(
     # main timing logic which is in turn dictated by nhl.com                     #
     ##############################################################################
 
-    async def game_check_loop(self):
+    async def game_check_loop(self) -> None:
         """
         This loop grabs the current games for the day
         then passes off to other functions as necessary
@@ -323,7 +323,7 @@ class Hockey(
 
             await asyncio.sleep(300)
 
-    async def check_new_day(self):
+    async def check_new_day(self) -> None:
         if not await self.config.created_gdc():
             if datetime.now().weekday() == 6:
                 try:
@@ -352,7 +352,7 @@ class Hockey(
             await self.check_new_gdc()
             await self.config.created_gdc.set(True)
 
-    async def change_custom_emojis(self, attachments):
+    async def change_custom_emojis(self, attachments: List[discord.Attachment]) -> None:
         """
         This overwrites the emojis in constants.py
          with values in a properly formatted .yaml file
@@ -377,7 +377,7 @@ class Hockey(
         with path.open("w") as outfile:
             outfile.write(constants_string)
 
-    async def wait_for_file(self, ctx):
+    async def wait_for_file(self, ctx: commands.Context) -> None:
         """
         Waits for the author to upload a file
         """

--- a/hockey/hockey_commands.py
+++ b/hockey/hockey_commands.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 from io import BytesIO
-from typing import Literal, Optional
+from typing import Literal, Optional, List
 from urllib.parse import quote
 
 import discord
@@ -42,21 +42,21 @@ class HockeyCommands(MixinMeta):
     #######################################################################
 
     @commands.group(name="hockey", aliases=["nhl"])
-    async def hockey_commands(self, ctx: commands.Context):
+    async def hockey_commands(self, ctx: commands.Context) -> None:
         """
         Get information from NHL.com
         """
         pass
 
     @hockey_commands.command()
-    async def version(self, ctx: commands.Context):
+    async def version(self, ctx: commands.Context) -> None:
         """
         Display the current version
         """
         await ctx.send(_("Hockey version ") + self.__version__)
 
     @commands.command()
-    async def hockeyhub(self, ctx: commands.Context, *, search: str):
+    async def hockeyhub(self, ctx: commands.Context, *, search: str) -> None:
         """
         Search for hockey related items on https://hockeyhub.github.io/
 
@@ -78,7 +78,7 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command(name="role")
     @commands.bot_has_permissions(manage_roles=True)
-    async def team_role(self, ctx: commands.Context, *, team: HockeyTeams):
+    async def team_role(self, ctx: commands.Context, *, team: HockeyTeams) -> None:
         """Set your role to a team role"""
         guild = ctx.message.guild
         if team is None:
@@ -98,7 +98,7 @@ class HockeyCommands(MixinMeta):
             await ctx.send(team + _(" is not an available role!"))
 
     @hockey_commands.command(name="goalsrole")
-    async def team_goals(self, ctx: commands.Context, *, team: HockeyTeams = None):
+    async def team_goals(self, ctx: commands.Context, *, team: HockeyTeams = None) -> None:
         """Subscribe to goal notifications"""
         guild = ctx.message.guild
         member = ctx.message.author
@@ -136,7 +136,7 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command()
     @commands.bot_has_permissions(embed_links=True)
-    async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None):
+    async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None) -> None:
         """
         Displays current standings
 
@@ -178,7 +178,9 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command(aliases=["score"])
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
-    async def games(self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}):
+    async def games(
+        self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}
+    ) -> None:
         """
         Gets all NHL games for the current season
 
@@ -201,7 +203,7 @@ class HockeyCommands(MixinMeta):
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
     async def schedule(
         self, ctx: commands.Context, *, teams_and_date: Optional[TeamDateFinder] = {}
-    ):
+    ) -> None:
         """
         Gets all upcoming NHL games for the current season as a list
 
@@ -222,7 +224,7 @@ class HockeyCommands(MixinMeta):
             timeout=60,
         ).start(ctx=ctx)
 
-    async def player_id_lookup(self, name: str):
+    async def player_id_lookup(self, name: str) -> List[int]:
         now = datetime.utcnow()
         saved = datetime.fromtimestamp(await self.config.player_db())
         path = cog_data_path(self) / "players.json"
@@ -252,7 +254,7 @@ class HockeyCommands(MixinMeta):
         ctx: commands.Context,
         *,
         search: str,
-    ):
+    ) -> None:
         """
         Lookup information about a specific player
 
@@ -297,7 +299,7 @@ class HockeyCommands(MixinMeta):
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
     async def roster(
         self, ctx: commands.Context, season: Optional[YearFinder] = None, *, search: HockeyTeams
-    ):
+    ) -> None:
         """
         Search for a player or get a team roster
 
@@ -359,7 +361,7 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command(hidden=True)
     @commands.mod_or_permissions(manage_messages=True)
-    async def rules(self, ctx: commands.Context):
+    async def rules(self, ctx: commands.Context) -> None:
         """
         Display a nice embed of server specific rules
         """
@@ -375,7 +377,7 @@ class HockeyCommands(MixinMeta):
         await ctx.send(embed=em)
 
     @staticmethod
-    async def make_rules_embed(guild, team, rules):
+    async def make_rules_embed(guild: discord.Guild, team: str, rules: str) -> discord.Embed:
         """
         Builds the rule embed for the server
         """
@@ -388,13 +390,13 @@ class HockeyCommands(MixinMeta):
         em.description = rules
         em.title = _("__RULES__")
         em.add_field(name=_("__**WARNING**__"), value=warning)
-        em.set_thumbnail(url=guild.icon_url)
-        em.set_author(name=guild.name, icon_url=guild.icon_url)
+        em.set_thumbnail(url=str(guild.icon_url))
+        em.set_author(name=guild.name, icon_url=str(guild.icon_url))
         return em
 
     async def post_leaderboard(
         self, ctx: commands.Context, leaderboard_type: Literal["season", "weekly", "worst"]
-    ):
+    ) -> None:
         """
         Posts the leaderboard based on specific style
         """
@@ -473,7 +475,7 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command()
     @commands.guild_only()
-    async def leaderboard(self, ctx: commands.Context, leaderboard_type: str = "seasonal"):
+    async def leaderboard(self, ctx: commands.Context, leaderboard_type: str = "seasonal") -> None:
         """
         Shows the current server leaderboard
 
@@ -493,7 +495,7 @@ class HockeyCommands(MixinMeta):
 
     @hockey_commands.command(hidden=True)
     @commands.mod_or_permissions(manage_messages=True)
-    async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules):
+    async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules) -> None:
         """Set the main rules page for the nhl rules command"""
         if team is None:
             return await ctx.send(_("You must provide a valid current team."))
@@ -506,7 +508,7 @@ class HockeyCommands(MixinMeta):
         await ctx.send(_("Done, here's how it will look."), embed=em)
 
     @hockey_commands.command(aliases=["link", "invite"])
-    async def otherdiscords(self, ctx: commands.Context, team: HockeyTeams):
+    async def otherdiscords(self, ctx: commands.Context, team: HockeyTeams) -> None:
         """
         Get team specific discord links
 

--- a/hockey/hockey_commands.py
+++ b/hockey/hockey_commands.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional
 from urllib.parse import quote
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 from redbot.core.data_manager import cog_data_path
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter
@@ -77,7 +77,7 @@ class HockeyCommands(MixinMeta):
         await ctx.send("https://hh.sbstp.ca/?search=" + search)
 
     @hockey_commands.command(name="role")
-    @checks.bot_has_permissions(manage_roles=True)
+    @commands.bot_has_permissions(manage_roles=True)
     async def team_role(self, ctx: commands.Context, *, team: HockeyTeams):
         """Set your role to a team role"""
         guild = ctx.message.guild
@@ -135,7 +135,7 @@ class HockeyCommands(MixinMeta):
                 await ctx.message.channel.send(team + _(" is not an available role!"))
 
     @hockey_commands.command()
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     async def standings(self, ctx: commands.Context, *, search: HockeyStandings = None):
         """
         Displays current standings
@@ -356,7 +356,7 @@ class HockeyCommands(MixinMeta):
             )
 
     @hockey_commands.command(hidden=True)
-    @checks.mod_or_permissions(manage_messages=True)
+    @commands.mod_or_permissions(manage_messages=True)
     async def rules(self, ctx: commands.Context):
         """
         Display a nice embed of server specific rules
@@ -490,7 +490,7 @@ class HockeyCommands(MixinMeta):
             await self.post_leaderboard(ctx, "worst")
 
     @hockey_commands.command(hidden=True)
-    @checks.mod_or_permissions(manage_messages=True)
+    @commands.mod_or_permissions(manage_messages=True)
     async def setrules(self, ctx: commands.Context, team: HockeyTeams, *, rules):
         """Set the main rules page for the nhl rules command"""
         if team is None:

--- a/hockey/hockey_commands.py
+++ b/hockey/hockey_commands.py
@@ -213,8 +213,10 @@ class HockeyCommands(MixinMeta):
         only that teams games may appear in that date range if they exist.
         """
         log.debug(teams_and_date)
+        timezone = await self.config.guild(ctx.guild).timezone()
+        log.debug(timezone)
         await GamesMenu(
-            source=ScheduleList(**teams_and_date, session=self.session),
+            source=ScheduleList(**teams_and_date, session=self.session, timezone=timezone),
             delete_message_after=False,
             clear_reactions_after=True,
             timeout=60,
@@ -396,7 +398,7 @@ class HockeyCommands(MixinMeta):
         """
         Posts the leaderboard based on specific style
         """
-        leaderboard = await self.config.guild(ctx.guild).leaderboard()
+        leaderboard = await self.pickems_config.guild(ctx.guild).leaderboard()
         if leaderboard == {} or leaderboard is None:
             await ctx.send(_("There is no current leaderboard for this server!"))
             return

--- a/hockey/hockey_commands.py
+++ b/hockey/hockey_commands.py
@@ -1,30 +1,28 @@
-import asyncio
 import json
 import logging
 from datetime import datetime, timedelta
 from io import BytesIO
-from typing import Optional, Literal
+from typing import Literal, Optional
 from urllib.parse import quote
 
-import aiohttp
 import discord
-from redbot.core import Config, checks, commands
-from redbot.core.bot import Red
-from redbot.core.i18n import Translator, cog_i18n
-from redbot.core.utils import AsyncIter
+from redbot.core import checks, commands
 from redbot.core.data_manager import cog_data_path
+from redbot.core.i18n import Translator
+from redbot.core.utils import AsyncIter
 
+from .abc import MixinMeta
 from .constants import BASE_URL, TEAMS
-from .helper import HockeyStandings, HockeyTeams, TeamDateFinder, YearFinder, YEAR_RE
+from .helper import YEAR_RE, HockeyStandings, HockeyTeams, TeamDateFinder, YearFinder
 from .menu import (
     BaseMenu,
     ConferenceStandingsPages,
     DivisionStandingsPages,
     GamesMenu,
     LeaderboardPages,
+    PlayerPages,
     StandingsPages,
     TeamStandingsPages,
-    PlayerPages,
 )
 from .schedule import Schedule, ScheduleList
 from .standings import Standings
@@ -34,28 +32,10 @@ _ = Translator("Hockey", __file__)
 log = logging.getLogger("red.trusty-cogs.Hockey")
 
 
-@cog_i18n(_)
-class HockeyCommands:
+class HockeyCommands(MixinMeta):
     """
     All the commands grouped under `[p]hockey`
     """
-
-    bot: Red
-    config: Config
-    TEST_LOOP: bool
-    all_pickems: dict
-    save_pickems: bool
-    pickems_save_lock: asyncio.Lock
-    session: aiohttp.ClientSession
-
-    def __init__(self, *args):
-        self.bot
-        self.config
-        self.TEST_LOOP
-        self.all_pickems
-        self.save_pickems
-        self.pickems_save_lock
-        self.session
 
     #######################################################################
     # All the basic commands                                              #

--- a/hockey/hockeypickems.py
+++ b/hockey/hockeypickems.py
@@ -187,12 +187,11 @@ class HockeyPickems(MixinMeta):
             guild = self.bot.get_guild(int(guild_id))
             if guild is None:
                 continue
-            if pickems is None:
-                pickems = {}
             pickems_channels = await self.pickems_config.guild(guild).pickems_channels()
             if str(game.game_id) in pickems:
                 pickem = self.all_pickems[str(guild_id)][str(game.game_id)]
                 if pickem.winner is not None:
+                    log.debug(f"Pickems winner is not None {repr(pickem)}")
                     continue
                 await self.all_pickems[str(guild_id)][str(game.game_id)].check_winner(game)
 
@@ -213,8 +212,10 @@ class HockeyPickems(MixinMeta):
     async def edit_pickems_message(
         self, channel: discord.TextChannel, message_id: int, game: Game
     ):
-        content = await self.make_pickems_msg(channel.guild, game)
+        log.debug("Editing Pickems")
+
         try:
+            content = await self.make_pickems_msg(channel.guild, game)
             if version_info >= VersionInfo.from_str("3.4.6"):
                 message = channel.get_partial_message(message_id)
             else:

--- a/hockey/hockeypickems.py
+++ b/hockey/hockeypickems.py
@@ -189,11 +189,10 @@ class HockeyPickems(MixinMeta):
                 continue
             if pickems is None:
                 pickems = {}
-            pickem_name = self.pickems_name(game)
             pickems_channels = await self.pickems_config.guild(guild).pickems_channels()
-            if pickem_name in pickems:
-                await self.all_pickems[str(guild_id)][pickem_name].check_winner(game)
-                pickem = self.all_pickems[str(guild_id)][pickem_name]
+            if str(game.game_id) in pickems:
+                await self.all_pickems[str(guild_id)][str(game.game_id)].check_winner(game)
+                pickem = self.all_pickems[str(guild_id)][str(game.game_id)]
                 for message in pickem.messages:
                     try:
                         channel_id, message_id = message.split("-")

--- a/hockey/hockeypickems.py
+++ b/hockey/hockeypickems.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from copy import copy
 from datetime import datetime, timedelta
@@ -9,7 +10,9 @@ from redbot import VersionInfo, version_info
 from redbot.core import commands
 from redbot.core.i18n import Translator
 from redbot.core.utils import AsyncIter, bounded_gather
+from redbot.core.utils.chat_formatting import humanize_list
 from redbot.core.utils.menus import start_adding_reactions
+
 
 from .abc import MixinMeta
 from .errors import NotAValidTeamError, UserHasVotedError, VotingHasEndedError
@@ -19,11 +22,17 @@ from .pickems import Pickems
 _ = Translator("Hockey", __file__)
 log = logging.getLogger("red.trusty-cogs.Hockey")
 
+hockeyset_commands = MixinMeta.hockeyset_commands
+# defined in abc.py allowing this to be inherited by multiple files
+
 
 class HockeyPickems(MixinMeta):
     """
     Hockey Pickems Logic
     """
+
+    def __init__(self, *args):
+        self.pickems_lock = asyncio.lock()
 
     @commands.Cog.listener()
     async def on_hockey_preview_message(self, channel, message, game):
@@ -49,34 +58,39 @@ class HockeyPickems(MixinMeta):
         # log.debug(payload.user_id)
         if not user or user.bot:
             return
-
+        log.debug("Checking pickems votes")
         for name, pickem in self.all_pickems[str(guild.id)].items():
-            if payload.message_id in pickem.message:
-                if (channel.id, payload.message_id) not in pickem.messages:
-                    pickem.messages.append((channel.id, payload.message_id))
+            if f"{channel.id}-{payload.message_id}" in pickem.messages:
                 reply_message = ""
                 remove_emoji = None
                 try:
                     # log.debug(payload.emoji)
+                    log.debug("Adding vote")
                     pickem.add_vote(user.id, payload.emoji)
                 except UserHasVotedError as team:
+                    log.debug("User has voted already")
                     remove_emoji = (
-                            pickem.home_emoji
-                            if str(payload.emoji.id) in pickem.away_emoji
-                            else pickem.away_emoji
-                        )
+                        pickem.home_emoji
+                        if str(payload.emoji.id) in pickem.away_emoji
+                        else pickem.away_emoji
+                    )
                     reply_message = _("You have already voted! Changing vote to: {team}").format(
                         team=team
                     )
                 except VotingHasEndedError as error_msg:
+                    log.debug("Voting has ended")
                     remove_emoji = payload.emoji
                     reply_message = _("Voting has ended! {voted_for}").format(
                         voted_for=str(error_msg)
                     )
                 except NotAValidTeamError:
+                    log.debug("Invalid emoji")
                     remove_emoji = payload.emoji
                     reply_message = _("Don't clutter the voting message with emojis!")
+                except Exception:
+                    log.exception(f"Error adding vote to {repr(pickems)}")
                 if remove_emoji and channel.permissions_for(guild.me).manage_messages:
+
                     try:
                         if version_info >= VersionInfo.from_str("3.4.6"):
                             msg = channel.get_partial_message(payload.message_id)
@@ -88,7 +102,10 @@ class HockeyPickems(MixinMeta):
                 if reply_message != "":
                     try:
                         await user.send(reply_message)
+                    except discord.HTTPException:
+                        log.error(f"Error trying to DM {repr(user)}")
                     except Exception:
+                        log.exception(f"Error trying to send message to {repr(user)}")
                         pass
 
     @tasks.loop(seconds=120)
@@ -164,9 +181,7 @@ class HockeyPickems(MixinMeta):
                 pickems = {}
             pickem_name = self.pickems_name(game)
             if pickem_name in pickems:
-                old_pickem = self.all_pickems[str(guild_id)][pickem_name]
-                new_pickem = await old_pickem.set_pickem_winner(game)
-                self.all_pickems[str(guild_id)][pickem_name] = new_pickem
+                await self.all_pickems[str(guild_id)][pickem_name].check_winner(game)
 
     async def create_pickem_object(
         self,
@@ -186,19 +201,13 @@ class HockeyPickems(MixinMeta):
         if pickems is None:
             self.all_pickems[str((guild.id))] = {}
             pickems = {}
-        old_pickem = None
-        old_name = None
-        for name, p in pickems.items():
-            if p.compare_game(game):
-                log.debug("Pickem already exists, adding channel")
-                old_pickem = p
-                old_name = name
+        old_pickem = self.all_pickems[str(guild.id)].get(new_name, None)
 
         if old_pickem is None:
             pickems[new_name] = Pickems.from_json(
                 {
                     "message": [message.id],
-                    "messages": [(channel.id, message.id)],
+                    "messages": [f"{channel.id}-{message.id}"],
                     "game_start": game.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "home_team": game.home_team,
                     "away_team": game.away_team,
@@ -210,21 +219,17 @@ class HockeyPickems(MixinMeta):
             )
 
             self.all_pickems[str(guild.id)] = pickems
-            log.debug("creating new pickems")
-            log.debug(pickems)
+            log.debug(f"creating new pickems {pickems}")
             return True
         else:
-            # del pickems[old_name]
-            # old_pickem["message"].append(message.id)
-            # old_pickem["channel"].append(channel.id)
             old_pickem.message.append(message.id)
             # The message attribute should eventually be removed
             # This has been running fine but I'd feel safer actually
             # saving channel ID's for compatibility
-            old_pickem.messages.append((channel.id, message.id))
+            old_pickem.messages.append(f"{channel.id}-{message.id}")
             if not old_pickem.link:
                 old_pickem.link = game.link
-            pickems[old_name] = old_pickem
+            pickems[old_pickem.name] = old_pickem
             # self.all_pickems[str(guild.id)] = pickems
             log.debug("using old pickems")
             return False
@@ -364,6 +369,7 @@ class HockeyPickems(MixinMeta):
         async for name, pickems in AsyncIter(pickems_list.items(), steps=50):
             # check for definitive winner here just incase
             if await pickems.check_winner():
+                log.debug(f"Tallying results for {repr(pickems)}")
                 to_remove.append(name)
                 async with self.pickems_config.guild(guild).leaderboard() as leaderboard:
                     for user, choice in pickems.votes.items():
@@ -380,6 +386,7 @@ class HockeyPickems(MixinMeta):
                         leaderboard[str(user)]["total"] += 1
         for name in to_remove:
             try:
+                log.debug(f"Removing pickem {name}")
                 del self.all_pickems[str(guild.id)][name]
             except Exception:
                 log.error("Error removing pickems from memory", exc_info=True)
@@ -397,3 +404,231 @@ class HockeyPickems(MixinMeta):
                 await self.tally_guild_leaderboard(guild)
             except Exception:
                 log.exception(f"Error tallying leaderboard in {guild.name}")
+
+    @hockeyset_commands.group(name="pickems")
+    @commands.admin_or_permissions(manage_channels=True)
+    async def pickems_commands(self, ctx: commands.Context):
+        """
+        Commands for managing pickems
+        """
+        pass
+
+    @pickems_commands.command(name="settings")
+    async def pickems_settings(self, ctx: commands.Context):
+        """
+        Show the servers current pickems settings
+        """
+        data = await self.pickems_config.guild(ctx.guild).all()
+        category_channel = ctx.guild.get_channel(data.get("pickems_category"))
+        category = category_channel.mention if category_channel else None
+        msg = _("Pickems Settings for {guild}\nCategory: {category}\nChannels: {channels}").format(
+            guild=ctx.guild.name,
+            category=category,
+            channels=humanize_list([f"<#{chan}>" for chan in data.get("pickems_channels")]),
+        )
+        await ctx.maybe_send_embed(msg)
+
+    @pickems_commands.command(name="setup", aliases=["auto", "set"])
+    @commands.admin_or_permissions(manage_channels=True)
+    async def setup_auto_pickems(
+        self, ctx: commands.Context, category: Optional[discord.CategoryChannel] = None
+    ):
+        """
+        Sets up automatically created pickems channels every week.
+
+        `[category]` the channel category where pickems channels will be created.
+        This must be the category ID. If not provided this will use the current
+        channels category if it exists.
+        """
+
+        if category is None and not ctx.channel.category:
+            return await ctx.send(_("A channel category is required."))
+        elif category is None and ctx.channel.category is not None:
+            category = ctx.channel.category
+
+        if not category.permissions_for(ctx.me).manage_channels:
+            await ctx.send(_("I don't have manage channels permission!"))
+            return
+
+        await self.pickems_config.guild(ctx.guild).pickems_category.set(category.id)
+        existing_channels = await self.pickems_config.guild(ctx.guild).pickems_channels()
+        if existing_channels:
+            cant_delete = []
+            for chan_id in existing_channels:
+                channel = ctx.guild.get_channel(chan_id)
+                if channel:
+                    try:
+                        await channel.delete()
+                    except discord.errors.Forbidden:
+                        cant_delete.append(chan_id)
+                await self.pickems_config.guild(ctx.guild).pickems_channels.clear()
+                if cant_delete:
+                    chans = humanize_list([f"<#{_id}>" for _id in cant_delete])
+                    await ctx.send(
+                        _(
+                            "I tried to delete the following channels without success:\n{chans}"
+                        ).format(chans=chans)
+                    )
+        await self.create_weekly_pickems_pages([ctx.guild], Game)
+        await ctx.send(_("I will now automatically create pickems pages every Sunday."))
+
+    @pickems_commands.command(name="clear")
+    @commands.admin_or_permissions(manage_channels=True)
+    async def delete_auto_pickems(self, ctx: commands.Context):
+        """
+        Automatically delete all the saved pickems channels.
+        """
+        existing_channels = await self.pickems_config.guild(ctx.guild).pickems_channels()
+        if existing_channels:
+            cant_delete = []
+            for chan_id in existing_channels:
+                channel = ctx.guild.get_channel(chan_id)
+                if channel:
+                    try:
+                        await channel.delete()
+                    except discord.errors.Forbidden:
+                        cant_delete.append(chan_id)
+                await self.pickems_config.guild(ctx.guild).pickems_channels.clear()
+                if cant_delete:
+                    chans = humanize_list([f"<#{_id}>" for _id in cant_delete])
+                    await ctx.send(
+                        _(
+                            "I tried to delete the following channels without success:\n{chans}"
+                        ).format(chans=chans)
+                    )
+        await ctx.send(_("I have deleted existing pickems channels."))
+
+    @pickems_commands.command(name="toggle")
+    @commands.admin_or_permissions(manage_channels=True)
+    async def toggle_auto_pickems(self, ctx: commands.Context):
+        """
+        Turn off automatic pickems page creation
+        """
+        await self.pickems_config.guild(ctx.guild).pickems_category.clear()
+        await ctx.send(_("I will not automatically generate pickems in this server."))
+
+    @pickems_commands.command(name="page")
+    @commands.admin_or_permissions(manage_channels=True)
+    async def pickems_page(self, ctx, date: Optional[str] = None):
+        """
+        Generates a pickems page for voting on a specified day must be "YYYY-MM-DD"
+        """
+        if date is None:
+            new_date = datetime.now()
+        else:
+            try:
+                new_date = datetime.strptime(date, "%Y-%m-%d")
+            except ValueError:
+                return await ctx.send(_("`date` must be in the format `YYYY-MM-DD`."))
+        msg = _(
+            "**Welcome to our daily Pick'ems challenge!  Below you will see today's games!"
+            "  Vote for who you think will win!  You get one point for each correct prediction."
+            "  We will be tracking points over the course "
+            "of the season and will be rewarding weekly,"
+            " worst and full-season winners!**\n\n"
+            "- Click the reaction for the team you think will win the day's match-up.\n"
+            "- Anyone who votes for both teams will have their "
+            "vote removed and will receive no points!\n\n\n\n"
+        )
+        games_list = await Game.get_games(None, new_date, new_date, session=self.session)
+        await ctx.send(msg)
+        for game in games_list:
+            new_msg = await ctx.send(
+                "__**{} {}**__ @ __**{} {}**__".format(
+                    game.away_emoji, game.away_team, game.home_emoji, game.home_team
+                )
+            )
+            # Create new pickems object for the game
+
+            await self.create_pickem_object(ctx.guild, new_msg, ctx.channel, game)
+            if ctx.channel.permissions_for(ctx.guild.me).add_reactions:
+                try:
+                    await new_msg.add_reaction(game.away_emoji[2:-1])
+                    await new_msg.add_reaction(game.home_emoji[2:-1])
+                except Exception:
+                    log.debug("Error adding reactions")
+
+    @pickems_commands.command(name="remove")
+    async def rempickem(self, ctx: commands.Context, true_or_false: bool):
+        """
+        Clears the servers current pickems object list
+
+        `<true_or_false>` `True` if you're sure you want to clear the settings.
+        """
+        if true_or_false:
+            await self.pickems_config.guild(ctx.guild).pickems.clear()
+            try:
+                del self.all_pickems[str(ctx.guild.id)]
+            except KeyError:
+                pass
+            await ctx.send(_("All pickems removed on this server."))
+        else:
+            await ctx.send(_("I will not remove the current pickems on this server."))
+
+    @pickems_commands.group(name="leaderboard")
+    async def pickems_leaderboard_commands(self, ctx: commands.Context):
+        """
+        Settings for clearing/resetting pickems leaderboards
+        """
+        pass
+
+    @pickems_leaderboard_commands.command(name="clear")
+    async def clear_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        """
+        Clears the entire pickems leaderboard in the server.
+
+        `<true_or_false>` `True` if you're sure you want to clear the settings.
+        """
+        if true_or_false:
+            await self.pickems_config.guild(ctx.guild).leaderboard.clear()
+            await ctx.send(_("Server leaderboard reset."))
+        else:
+            await ctx.send(_("I will not reset the pickems leaderboard in this server."))
+
+    @pickems_leaderboard_commands.command(name="tally")
+    async def tally_server_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        """
+        Manually tallies this servers pickems leaderboard incase votes
+        aren't working properly.
+
+        `<true_or_false>` `True` if you're sure you want to clear the settings.
+        """
+        if true_or_false:
+            await self.tally_guild_leaderboard(ctx.guild)
+            await ctx.send(_("Server leaderboard has been saved."))
+        else:
+            await ctx.send(_("I will not tally this servers pickems leaderboard."))
+
+    @pickems_leaderboard_commands.command(name="clearweekly")
+    async def clear_weekly_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        """
+        Clears the weekly tracker on the current servers pickems
+
+        `<true_or_false>` `True` if you're sure you want to clear the settings.
+        """
+        if true_or_false:
+            async with self.pickems_config.guild(ctx.guild).leaderboard() as leaderboard:
+                if leaderboard is None:
+                    leaderboard = {}
+                for user in leaderboard:
+                    leaderboard[str(user)]["weekly"] = 0
+            await ctx.send(_("Servers weekly leaderboard reset."))
+        else:
+            await ctx.send(_("I will not reset the pickems weekly leaderboard in this server."))
+
+    @pickems_leaderboard_commands.command(name="clearseason")
+    async def clear_seasonal_leaderboard(self, ctx: commands.Context, true_or_false: bool):
+        """
+        Clears the weekly tracker on the current servers pickems
+
+        `<true_or_false>` `True` if you're sure you want to clear the settings.
+        """
+        if true_or_false:
+            async with self.pickems_config.guild(ctx.guild).leaderboard() as leaderboard:
+                if leaderboard is None:
+                    leaderboard = {}
+                for user in leaderboard:
+                    leaderboard[str(user)]["season"] = 0
+            await ctx.send(_("Servers weekly leaderboard reset."))
+        else:
+            await ctx.send(_("I will not reset the pickems seasonal leaderboard in this server."))

--- a/hockey/hockeypickems.py
+++ b/hockey/hockeypickems.py
@@ -1,0 +1,395 @@
+import logging
+from copy import copy
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import discord
+from discord.ext import tasks
+from redbot import VersionInfo, version_info
+from redbot.core import commands
+from redbot.core.i18n import Translator
+from redbot.core.utils import AsyncIter, bounded_gather
+from redbot.core.utils.menus import start_adding_reactions
+
+from .abc import MixinMeta
+from .errors import NotAValidTeamError, UserHasVotedError, VotingHasEndedError
+from .game import Game
+from .pickems import Pickems
+
+_ = Translator("Hockey", __file__)
+log = logging.getLogger("red.trusty-cogs.Hockey")
+
+
+class HockeyPickems(MixinMeta):
+    """
+    Hockey Pickems Logic
+    """
+
+    @commands.Cog.listener()
+    async def on_hockey_preview_message(self, channel, message, game):
+        """
+        Handles adding preview messages to the pickems object.
+        """
+        # a little hack to avoid circular imports
+        await self.create_pickem_object(channel.guild, message, channel, game)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload):
+        if payload.guild_id is None:
+            return
+        guild = self.bot.get_guild(payload.guild_id)
+        if not guild:
+            return
+        channel = guild.get_channel(payload.channel_id)
+        if not channel:
+            return
+        if str(guild.id) not in self.all_pickems:
+            return
+        user = guild.get_member(payload.user_id)
+        # log.debug(payload.user_id)
+        if not user or user.bot:
+            return
+
+        for name, pickem in self.all_pickems[str(guild.id)].items():
+            if payload.message_id in pickem.message:
+                if (channel.id, payload.message_id) not in pickem.messages:
+                    pickem.messages.append((channel.id, payload.message_id))
+                reply_message = ""
+                remove_emoji = False
+                try:
+                    # log.debug(payload.emoji)
+                    pickem.add_vote(user.id, payload.emoji)
+                except UserHasVotedError as team:
+                    remove_emoji = True
+                    reply_message = _("You have already voted! Changing vote to: {team}").format(
+                        team=team
+                    )
+                except VotingHasEndedError as error_msg:
+                    remove_emoji = True
+                    reply_message = _("Voting has ended! {voted_for}").format(
+                        voted_for=str(error_msg)
+                    )
+                except NotAValidTeamError:
+                    remove_emoji = True
+                    reply_message = _("Don't clutter the voting message with emojis!")
+                if remove_emoji and channel.permissions_for(guild.me).manage_messages:
+                    try:
+                        if version_info >= VersionInfo.from_str("3.4.6"):
+                            msg = channel.get_partial_message(payload.message_id)
+                        else:
+                            msg = await channel.fetch_message(id=payload.message_id)
+                        await msg.remove_reaction(payload.emoji, user)
+                    except (discord.errors.NotFound, discord.errors.Forbidden):
+                        pass
+                if reply_message != "":
+                    try:
+                        await user.send(reply_message)
+                    except Exception:
+                        pass
+
+    @tasks.loop(seconds=120)
+    async def pickems_loop(self):
+        await self.save_pickems_data()
+        log.debug("Saved pickems data.")
+
+    async def save_pickems_data(self):
+        try:
+
+            log.debug("Saving pickems data")
+            all_pickems = copy(self.all_pickems)
+            for guild_id, pickems in all_pickems.items():
+                data = {}
+                for name, pickem in pickems.items():
+                    data[name] = pickem.to_json()
+                await self.pickems_config.guild_from_id(guild_id).pickems.set(data)
+        except Exception:
+            log.exception("Error saving pickems Data")
+            # catch all errors cause we don't want this loop to fail for something dumb
+
+    @pickems_loop.after_loop
+    async def after_pickems_loop(self):
+        if self.pickems_loop.is_being_cancelled():
+            await self.save_pickems_data()
+
+    @pickems_loop.before_loop
+    async def before_pickems_loop(self):
+        await self.bot.wait_until_ready()
+        await self._ready.wait()
+        # wait until migration if necessary
+        all_data = await self.pickems_config.all_guilds()
+        for guild_id, data in all_data.items():
+            pickems_list = data.get("pickems", {})
+            if pickems_list is None:
+                log.info(f"Resetting pickems in {guild_id} for incompatible type")
+                await self.pickems_config.guild_from_id(guild_id).pickems.clear()
+                continue
+            if type(pickems_list) is list:
+                log.info(f"Resetting pickems in {guild_id} for incompatible type")
+                await self.pickems_config.guild_from_id(guild_id).pickems.clear()
+                continue
+            # pickems = [Pickems.from_json(p) for p in pickems_list]
+            pickems = {name: Pickems.from_json(p) for name, p in pickems_list.items()}
+            self.all_pickems[str(guild_id)] = pickems
+
+    def pickems_name(self, game: Game) -> str:
+        return f"{game.away_abr}@{game.home_abr}-{game.game_start.month}-{game.game_start.day}"
+
+    async def find_pickems_object(self, game: Game) -> List[Pickems]:
+        """
+        Returns a list of all pickems on the bot for that game
+        """
+        return_pickems = []
+        new_name = f"{game.away_abr}@{game.home_abr}-{game.game_start.month}-{game.game_start.day}"
+        for guild_id, pickems in self.all_pickems.items():
+            guild = self.bot.get_guild(int(guild_id))
+            if guild is None:
+                continue
+            if pickems is None:
+                pickems = []
+            if new_name in pickems:
+                return_pickems.append(pickems[new_name])
+
+        return return_pickems
+
+    async def set_guild_pickem_winner(self, game: Game):
+        for guild_id, pickems in self.all_pickems.items():
+            guild = self.bot.get_guild(int(guild_id))
+            if guild is None:
+                continue
+            if pickems is None:
+                pickems = {}
+            pickem_name = self.pickems_name(game)
+            if pickem_name in pickems:
+                old_pickem = self.all_pickems[str(guild_id)][pickem_name]
+                new_pickem = await old_pickem.set_pickem_winner(game)
+                self.all_pickems[str(guild_id)][pickem_name] = new_pickem
+
+    async def create_pickem_object(
+        self,
+        guild: discord.Guild,
+        message: discord.Message,
+        channel: discord.TextChannel,
+        game: Game,
+    ) -> bool:
+        """
+        Checks to see if a pickem object is already created for the game
+        if not it creates one or adds the message, channel to the current ones
+        """
+        pickems = self.all_pickems.get(str(guild.id), None)
+        new_name = self.pickems_name(game)
+        if type(pickems) is list:
+            pickems = {}
+        if pickems is None:
+            self.all_pickems[str((guild.id))] = {}
+            pickems = {}
+        old_pickem = None
+        old_name = None
+        for name, p in pickems.items():
+            if p.compare_game(game):
+                log.debug("Pickem already exists, adding channel")
+                old_pickem = p
+                old_name = name
+
+        if old_pickem is None:
+            pickems[new_name] = Pickems.from_json(
+                {
+                    "message": [message.id],
+                    "messages": [(channel.id, message.id)],
+                    "game_start": game.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "home_team": game.home_team,
+                    "away_team": game.away_team,
+                    "votes": {},
+                    "name": new_name,
+                    "winner": None,
+                    "link": game.link,
+                }
+            )
+
+            self.all_pickems[str(guild.id)] = pickems
+            log.debug("creating new pickems")
+            log.debug(pickems)
+            return True
+        else:
+            # del pickems[old_name]
+            # old_pickem["message"].append(message.id)
+            # old_pickem["channel"].append(channel.id)
+            old_pickem.message.append(message.id)
+            # The message attribute should eventually be removed
+            # This has been running fine but I'd feel safer actually
+            # saving channel ID's for compatibility
+            old_pickem.messages.append((channel.id, message.id))
+            if not old_pickem.link:
+                old_pickem.link = game.link
+            pickems[old_name] = old_pickem
+            # self.all_pickems[str(guild.id)] = pickems
+            log.debug("using old pickems")
+            return False
+
+    async def reset_weekly(self):
+        # Reset the weekly leaderboard for all servers
+        pickems_channels_to_delete = []
+        async for guild_id, data in AsyncIter(
+            (await self.pickems_config.all_guilds()).items(), steps=100
+        ):
+            guild = self.bot.get_guild(id=guild_id)
+            if guild is None:
+                continue
+            leaderboard = await self.pickems_config.guild(guild).leaderboard()
+            try:
+                current_guild_pickem_channels = await self.pickems_config.guild(
+                    guild
+                ).pickems_channels()
+                if current_guild_pickem_channels:
+                    pickems_channels_to_delete += current_guild_pickem_channels
+            except Exception:
+                log.error("Error adding channels to delete", exc_info=True)
+            if leaderboard is None:
+                leaderboard = {}
+            for user in leaderboard:
+                leaderboard[str(user)]["weekly"] = 0
+            await self.pickems_config.guild(guild).leaderboard.set(leaderboard)
+        try:
+            await self.delete_pickems_channels(pickems_channels_to_delete)
+        except Exception:
+            log.error("Error deleting pickems Channels", exc_info=True)
+
+    async def create_pickems_channel(
+        self, name: str, guild: discord.Guild
+    ) -> Optional[discord.TextChannel]:
+        msg = _(
+            "**Welcome to our daily Pick'ems challenge!  Below you will see today's games!"
+            "  Vote for who you think will win!  You get one point for each correct prediction."
+            "  We will be tracking points over the course "
+            "of the season and will be rewarding weekly,"
+            " worst and full-season winners!**\n\n"
+            "- Click the reaction for the team you think will win the day's match-up.\n"
+            "- Anyone who votes for both teams will have their "
+            "vote removed and will receive no points!\n\n\n\n"
+        )
+        category = guild.get_channel(await self.pickems_config.guild(guild).pickems_category())
+        if not category:
+            return None
+        try:
+            new_chn = await guild.create_text_channel(name, category=category)
+            await new_chn.send(msg)
+        except discord.errors.Forbidden:
+            await self.pickems_config.guild(guild).pickems_category.clear()
+            return None
+        return new_chn
+
+    async def create_pickems_game_msg(self, channel: discord.TextChannel, game: Game):
+        try:
+            new_msg = await channel.send(
+                "__**{} {}**__ @ __**{} {}**__".format(
+                    game.away_emoji, game.away_team, game.home_emoji, game.home_team
+                )
+            )
+        except Exception:
+            log.error("Error sending messages in pickems channel.")
+            return
+        # Create new pickems object for the game
+        try:
+            await self.create_pickem_object(channel.guild, new_msg, channel, game)
+        except Exception as e:
+            log.error("Error creating pickems Object.", exc_info=e)
+        if channel.permissions_for(channel.guild.me).add_reactions:
+            start_adding_reactions(new_msg, [game.away_emoji[2:-1], game.home_emoji[2:-1]])
+
+    async def create_weekly_pickems_pages(self, guilds: List[discord.Guild], game_obj: Game):
+        save_data = {}
+        today = datetime.now()
+        new_day = timedelta(days=1)
+        count = 0
+
+        while True:
+            chn_name = _("pickems-{month}-{day}").format(month=today.month, day=today.day)
+            data = []
+            channel_tasks = []
+            for guild in guilds:
+                channel_tasks.append(self.create_pickems_channel(chn_name, guild))
+            data = await bounded_gather(*channel_tasks)
+
+            for new_channel in data:
+                if new_channel is None:
+                    continue
+                if new_channel.guild.id not in save_data:
+                    save_data[new_channel.guild.id] = [new_channel.id]
+                else:
+                    save_data[new_channel.guild.id].append(new_channel.id)
+
+            games_list = await game_obj.get_games(None, today, today, self.session)
+
+            msg_tasks = []
+            for game in games_list:
+                for channel in data:
+                    if channel:
+                        msg_tasks.append(self.create_pickems_game_msg(channel, game))
+            await bounded_gather(*msg_tasks)
+
+            today = today + new_day
+            count += 1
+            if today.weekday() == 6 or count == 7:
+                # just incase we end up in an infinite loop somehow
+                # can never be too careful with async coding
+                break
+        for guild_id, channels in save_data.items():
+            guild = self.bot.get_guild(guild_id)
+            if not guild:
+                continue
+            await self.pickems_config.guild(guild).pickems_channels.set(channels)
+
+    async def delete_pickems_channels(self, channels: List[int]):
+        log.debug("Deleting pickems channels")
+        for channel_id in channels:
+            channel = self.bot.get_channel(channel_id)
+            if not channel:
+                continue
+            try:
+                await channel.delete()
+            except discord.errors.Forbidden:
+                pass
+            except Exception:
+                log.error("Error deleting old pickems channels", exc_info=True)
+
+    async def tally_guild_leaderboard(self, guild: discord.Guild):
+        """
+        Allows individual guilds to tally pickems leaderboard
+        """
+        pickems_list = copy(self.all_pickems.get(str(guild.id)))
+        to_remove = []
+        async for name, pickems in AsyncIter(pickems_list.items(), steps=50):
+            # check for definitive winner here just incase
+            if await pickems.check_winner():
+                to_remove.append(name)
+                async with self.pickems_config.guild(guild).leaderboard() as leaderboard:
+                    for user, choice in pickems.votes.items():
+                        if str(user) not in leaderboard:
+                            leaderboard[str(user)] = {"season": 0, "weekly": 0, "total": 0}
+                        if choice == pickems.winner:
+                            if str(user) not in leaderboard:
+                                leaderboard[str(user)] = {"season": 1, "weekly": 1, "total": 0}
+                            else:
+                                leaderboard[str(user)]["season"] += 1
+                                leaderboard[str(user)]["weekly"] += 1
+                        if "total" not in leaderboard[str(user)]:
+                            leaderboard[str(user)]["total"] = 0
+                        leaderboard[str(user)]["total"] += 1
+        for name in to_remove:
+            try:
+                del self.all_pickems[str(guild.id)][name]
+            except Exception:
+                log.error("Error removing pickems from memory", exc_info=True)
+
+    async def tally_leaderboard(self):
+        """
+        This should be where the pickems is removed and tallies are added
+        to the leaderboard
+        """
+        async for guild_id in AsyncIter(self.all_pickems.keys(), steps=100):
+            guild = self.bot.get_guild(id=int(guild_id))
+            if guild is None:
+                continue
+            try:
+                await self.tally_guild_leaderboard(guild)
+            except Exception:
+                log.exception(f"Error tallying leaderboard in {guild.name}")

--- a/hockey/hockeyset.py
+++ b/hockey/hockeyset.py
@@ -26,7 +26,7 @@ class HockeySetCommands(MixinMeta):
     """
 
     @hockeyset_commands.command(name="settings")
-    async def hockey_settings(self, ctx: commands.Context):
+    async def hockey_settings(self, ctx: commands.Context) -> None:
         """
         Show hockey settings for this server
         """
@@ -114,7 +114,7 @@ class HockeySetCommands(MixinMeta):
 
     @hockeyset_commands.command(hidden=True)
     @commands.admin_or_permissions(administrator=True)
-    async def reset(self, ctx: commands.Context):
+    async def reset(self, ctx: commands.Context) -> None:
         """
         Restarts the hockey loop incase there are issues with the posts
         """
@@ -130,7 +130,7 @@ class HockeySetCommands(MixinMeta):
     )
     async def set_hockey_timezone(
         self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
-    ):
+    ) -> None:
         """
         Customize the servers timezone
 
@@ -150,7 +150,7 @@ class HockeySetCommands(MixinMeta):
             await ctx.send(msg)
 
     @set_hockey_timezone.command(name="list")
-    async def list_hockey_timezones(self, ctx: commands.Context):
+    async def list_hockey_timezones(self, ctx: commands.Context) -> None:
         """
         List the available timezones for pickems messages
         """
@@ -177,7 +177,7 @@ class HockeySetCommands(MixinMeta):
         season: int,
         weekly: int = None,
         total: int = None,
-    ):
+    ) -> None:
         """
         Allows moderators to set a users points on the leaderboard
         """
@@ -231,7 +231,7 @@ class HockeySetCommands(MixinMeta):
         return reply
 
     @hockeyset_commands.group(name="notifications")
-    async def hockey_notifications(self, ctx: commands.Context):
+    async def hockey_notifications(self, ctx: commands.Context) -> None:
         """
         Settings related to role notifications
         """
@@ -241,7 +241,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_goal_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the servers goal notification style. Options are:
 
@@ -281,7 +281,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_ot_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the servers Regular Season OT notification style. Options are:
 
@@ -323,7 +323,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_so_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the servers Shootout notification style. Options are:
 
@@ -365,7 +365,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_game_start_notification_style(
         self, ctx: commands.Context, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the servers game start notification style. Options are:
 
@@ -403,7 +403,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_channel_goal_notification_style(
         self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the specified channels goal notification style. Options are:
 
@@ -446,7 +446,7 @@ class HockeySetCommands(MixinMeta):
     @commands.mod_or_permissions(manage_roles=True)
     async def set_channel_game_start_notification_style(
         self, ctx: commands.Context, channel: discord.TextChannel, on_off: Optional[bool] = None
-    ):
+    ) -> None:
         """
         Set the specified channels game start notification style. Options are:
 
@@ -492,7 +492,7 @@ class HockeySetCommands(MixinMeta):
         ctx: commands.Context,
         standings_type: str,
         channel: Optional[discord.TextChannel] = None,
-    ):
+    ) -> None:
         """
         Posts automatic standings when all games for the day are done
 
@@ -532,7 +532,7 @@ class HockeySetCommands(MixinMeta):
         await self.config.guild(guild).post_standings.set(True)
 
     @hockeyset_commands.command()
-    async def togglestandings(self, ctx: commands.Context):
+    async def togglestandings(self, ctx: commands.Context) -> None:
         """
         Toggles automatic standings updates
 
@@ -548,7 +548,7 @@ class HockeySetCommands(MixinMeta):
     @hockeyset_commands.command(name="stateupdates")
     async def set_game_state_updates(
         self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
-    ):
+    ) -> None:
         """
         Set what type of game updates to be posted in the designated channel.
 
@@ -582,7 +582,7 @@ class HockeySetCommands(MixinMeta):
     @commands.is_owner()
     async def set_game_publish_updates(
         self, ctx: commands.Context, channel: discord.TextChannel, *state: HockeyStates
-    ):
+    ) -> None:
         """
         Set what type of game updates will be published in the designated news channel.
 
@@ -621,7 +621,7 @@ class HockeySetCommands(MixinMeta):
     @hockeyset_commands.command(name="add", aliases=["addgoals"])
     async def add_goals(
         self, ctx: commands.Context, team: HockeyTeams, channel: Optional[discord.TextChannel]
-    ):
+    ) -> None:
         """
         Adds a hockey team goal updates to a channel do 'all' for all teams
 
@@ -659,7 +659,7 @@ class HockeySetCommands(MixinMeta):
         ctx: commands.Context,
         team: Optional[HockeyTeams] = None,
         channel: Optional[discord.TextChannel] = None,
-    ):
+    ) -> None:
         """
         Removes a teams goal updates from a channel
         defaults to the current channel

--- a/hockey/hockeyset.py
+++ b/hockey/hockeyset.py
@@ -112,19 +112,6 @@ class HockeySetCommands(MixinMeta):
     # All Hockey setup commands                                           #
     #######################################################################
 
-    @hockeyset_commands.command(hidden=True)
-    @commands.admin_or_permissions(administrator=True)
-    async def reset(self, ctx: commands.Context) -> None:
-        """
-        Restarts the hockey loop incase there are issues with the posts
-        """
-        msg = await ctx.send(_("Restarting..."))
-        self.loop.cancel()
-        await msg.edit(content=msg.content + _("loop closed..."))
-        self.loop = self.bot.loop.create_task(self.game_check_loop())
-        await msg.edit(content=msg.content + _("restarted"))
-        # await ctx.send("Done.")
-
     @hockeyset_commands.group(
         name="timezone", aliases=["timezones", "tz"], invoke_without_command=True
     )
@@ -168,38 +155,6 @@ class HockeySetCommands(MixinMeta):
             clear_reactions_after=True,
             timeout=60,
         ).start(ctx=ctx)
-
-    @hockeyset_commands.command(hidden=True)
-    async def leaderboardset(
-        self,
-        ctx: commands.Context,
-        user: discord.Member,
-        season: int,
-        weekly: int = None,
-        total: int = None,
-    ) -> None:
-        """
-        Allows moderators to set a users points on the leaderboard
-        """
-        if weekly is None:
-            weekly = season
-        if total is None:
-            total = season
-        leaderboard = await self.config.guild(ctx.guild).leaderboard()
-        if leaderboard == {} or leaderboard is None:
-            await ctx.send(_("There is no current leaderboard for this server!"))
-            return
-        if str(user.id) not in leaderboard:
-            leaderboard[str(user.id)] = {"season": season, "weekly": weekly, "total": total}
-        else:
-            del leaderboard[str(user.id)]
-            leaderboard[str(user.id)] = {"season": season, "weekly": weekly, "total": total}
-        await self.config.guild(ctx.guild).leaderboard.set(leaderboard)
-        msg = _(
-            "{user} now has {season} points on the season, "
-            "{weekly} points for the week, and {total} votes overall."
-        ).format(user=user.display_name, season=season, weekly=weekly, total=total)
-        await ctx.send(msg)
 
     async def check_notification_settings(self, guild: discord.Guild) -> str:
         reply = ""

--- a/hockey/hockeyset.py
+++ b/hockey/hockeyset.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import discord
 from redbot.core import commands
-from redbot.core.i18n import Translator, cog_i18n
+from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import humanize_list, pagify
 
 from .abc import MixinMeta

--- a/hockey/hockeyset.py
+++ b/hockey/hockeyset.py
@@ -128,7 +128,9 @@ class HockeySetCommands(MixinMeta):
     @hockeyset_commands.group(
         name="timezone", aliases=["timezones", "tz"], invoke_without_command=True
     )
-    async def set_hockey_timezone(self, ctx: commands.Context, timezone: TimezoneFinder = None):
+    async def set_hockey_timezone(
+        self, ctx: commands.Context, timezone: Optional[TimezoneFinder] = None
+    ):
         """
         Customize the servers timezone
 
@@ -136,6 +138,7 @@ class HockeySetCommands(MixinMeta):
 
         `[timezone]` The full name of the timezone you want to set. For a list of
         available timezone names use `[p]hockeyset timezone list`
+        defaults to Home Teams Tmezone if not provided
         """
         if ctx.invoked_subcommand is None:
             if timezone is not None:

--- a/hockey/menu.py
+++ b/hockey/menu.py
@@ -42,7 +42,7 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
         )
         self.cog = cog
 
-    async def update(self, payload):
+    async def update(self, payload: discord.RawReactionActionEvent) -> None:
         """|coro|
 
         Updates the menu after an event has been received.
@@ -66,7 +66,9 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
         except Exception as exc:
             log.debug("Ignored exception on reaction event", exc_info=exc)
 
-    async def show_page(self, page_number, *, skip_next=False, skip_prev=False):
+    async def show_page(
+        self, page_number: int, *, skip_next: bool = False, skip_prev: bool = False
+    ) -> None:
         try:
             page = await self._source.get_page(
                 page_number, skip_next=skip_next, skip_prev=skip_prev
@@ -84,7 +86,9 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
         kwargs = await self._get_kwargs_from_page(page)
         await self.message.edit(**kwargs)
 
-    async def send_initial_message(self, ctx, channel):
+    async def send_initial_message(
+        self, ctx: commands.Context, channel: discord.TextChannel
+    ) -> discord.Message:
         """|coro|
         The default implementation of :meth:`Menu.send_initial_message`
         for the interactive pagination session.
@@ -114,7 +118,7 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
             # An error happened that can be handled, so ignore it.
             pass
 
-    def reaction_check(self, payload):
+    def reaction_check(self, payload: discord.RawReactionActionEvent) -> bool:
         """Just extends the default reaction_check to use owner_ids"""
         if payload.message_id != self.message.id:
             return False
@@ -122,13 +126,13 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
             return False
         return payload.emoji in self.buttons
 
-    def _skip_single_arrows(self):
+    def _skip_single_arrows(self) -> bool:
         max_pages = self._source.get_max_pages()
         if max_pages is None:
             return True
         return max_pages == 1
 
-    def _skip_double_arrows(self):
+    def _skip_double_arrows(self) -> bool:
         if isinstance(self._source, ScheduleList):
             return True
         return False
@@ -137,7 +141,7 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
         "\N{BLACK LEFT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}",
         position=menus.First(1),
     )
-    async def go_to_previous_page(self, payload):
+    async def go_to_previous_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the previous page"""
         await self.show_checked_page(self.current_page - 1)
 
@@ -145,7 +149,7 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
         "\N{BLACK RIGHT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}",
         position=menus.Last(0),
     )
-    async def go_to_next_page(self, payload):
+    async def go_to_next_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the next page"""
         # log.info(f"Moving to next page, {self.current_page + 1}")
         await self.show_checked_page(self.current_page + 1)
@@ -153,18 +157,18 @@ class GamesMenu(menus.MenuPages, inherit_buttons=False):
     @menus.button(
         "\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\N{VARIATION SELECTOR-16}",
         position=menus.First(0),
-        skip_if=_skip_double_arrows
+        skip_if=_skip_double_arrows,
     )
-    async def go_to_first_page(self, payload):
+    async def go_to_first_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the first page"""
         await self.show_page(0, skip_prev=True)
 
     @menus.button(
         "\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\N{VARIATION SELECTOR-16}",
         position=menus.Last(1),
-        skip_if=_skip_double_arrows
+        skip_if=_skip_double_arrows,
     )
-    async def go_to_last_page(self, payload):
+    async def go_to_last_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the last page"""
         # The call here is safe because it's guarded by skip_if
         await self.show_page(0, skip_next=True)
@@ -244,10 +248,10 @@ class StandingsPages(menus.ListPageSource):
         super().__init__(pages, per_page=1)
         self.pages = pages
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: List[Standings]) -> discord.Embed:
         return await Standings.all_standing_embed(self.pages)
 
 
@@ -255,10 +259,10 @@ class TeamStandingsPages(menus.ListPageSource):
     def __init__(self, pages: list):
         super().__init__(pages, per_page=1)
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: Standings) -> discord.Embed:
         return await Standings.make_team_standings_embed(page)
 
 
@@ -266,10 +270,10 @@ class ConferenceStandingsPages(menus.ListPageSource):
     def __init__(self, pages: list):
         super().__init__(pages, per_page=1)
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: List[Standings]) -> discord.Embed:
         return await Standings.make_conference_standings_embed(page)
 
 
@@ -277,10 +281,10 @@ class DivisionStandingsPages(menus.ListPageSource):
     def __init__(self, pages: list):
         super().__init__(pages, per_page=1)
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: List[Standings]) -> discord.Embed:
         return await Standings.make_division_standings_embed(page)
 
 
@@ -289,10 +293,10 @@ class LeaderboardPages(menus.ListPageSource):
         super().__init__(pages, per_page=1)
         self.style = style
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: List[str]) -> discord.Embed:
         em = discord.Embed(timestamp=datetime.utcnow())
         description = ""
         for msg in page:
@@ -310,13 +314,13 @@ class LeaderboardPages(menus.ListPageSource):
 class PlayerPages(menus.ListPageSource):
     def __init__(self, pages: list, season: str):
         super().__init__(pages, per_page=1)
-        self.pages = pages
-        self.season = season
+        self.pages: List[int] = pages
+        self.season: str = season
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: int) -> discord.Embed:
         player = await Player.from_id(page, session=menu.cog.session)
         log.debug(player)
         player = await player.get_full_stats(self.season, session=menu.cog.session)
@@ -329,10 +333,10 @@ class SimplePages(menus.ListPageSource):
     def __init__(self, pages: List[Union[discord.Embed, str]]):
         super().__init__(pages, per_page=1)
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
-    async def format_page(self, menu: menus.MenuPages, page):
+    async def format_page(self, menu: menus.MenuPages, page: Any) -> Union[discord.Embed, str]:
         if isinstance(page, discord.Embed):
             page.set_footer(text=f"Page {menu.current_page + 1}/{self.get_max_pages()}")
         return page
@@ -361,7 +365,9 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         self.cog = cog
         self.page_start = page_start
 
-    async def send_initial_message(self, ctx, channel):
+    async def send_initial_message(
+        self, ctx: commands.Context, channel: discord.TextChannel
+    ) -> discord.Message:
         """|coro|
         The default implementation of :meth:`Menu.send_initial_message`
         for the interactive pagination session.
@@ -371,7 +377,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         kwargs = await self._get_kwargs_from_page(page)
         return await channel.send(**kwargs)
 
-    async def update(self, payload):
+    async def update(self, payload: discord.RawReactionActionEvent) -> None:
         """|coro|
 
         Updates the menu after an event has been received.
@@ -411,7 +417,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
             # An error happened that can be handled, so ignore it.
             pass
 
-    def reaction_check(self, payload):
+    def reaction_check(self, payload: discord.RawReactionActionEvent) -> bool:
         """Just extends the default reaction_check to use owner_ids"""
         if payload.message_id != self.message.id:
             return False
@@ -419,7 +425,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
             return False
         return payload.emoji in self.buttons
 
-    def _skip_single_arrows(self):
+    def _skip_single_arrows(self) -> bool:
         if isinstance(self._source, StandingsPages):
             return True
         max_pages = self._source.get_max_pages()
@@ -427,7 +433,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
             return True
         return max_pages == 1
 
-    def _skip_double_triangle_buttons(self):
+    def _skip_double_triangle_buttons(self) -> bool:
         if isinstance(self._source, StandingsPages):
             return True
         max_pages = self._source.get_max_pages()
@@ -440,7 +446,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         position=menus.First(1),
         skip_if=_skip_single_arrows,
     )
-    async def go_to_previous_page(self, payload):
+    async def go_to_previous_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the previous page"""
         await self.show_checked_page(self.current_page - 1)
 
@@ -449,7 +455,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         position=menus.Last(0),
         skip_if=_skip_single_arrows,
     )
-    async def go_to_next_page(self, payload):
+    async def go_to_next_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the next page"""
         await self.show_checked_page(self.current_page + 1)
 
@@ -458,7 +464,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         position=menus.First(0),
         skip_if=_skip_double_triangle_buttons,
     )
-    async def go_to_first_page(self, payload):
+    async def go_to_first_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the first page"""
         await self.show_page(0)
 
@@ -467,7 +473,7 @@ class BaseMenu(menus.MenuPages, inherit_buttons=False):
         position=menus.Last(1),
         skip_if=_skip_double_triangle_buttons,
     )
-    async def go_to_last_page(self, payload):
+    async def go_to_last_page(self, payload: discord.RawReactionActionEvent) -> None:
         """go to the last page"""
         # The call here is safe because it's guarded by skip_if
         await self.show_page(self._source.get_max_pages() - 1)

--- a/hockey/menu.py
+++ b/hockey/menu.py
@@ -13,9 +13,9 @@ from redbot.vendored.discord.ext import menus
 from .constants import TEAMS
 from .errors import NoSchedule
 from .helper import DATE_RE
-from .standings import Standings
 from .player import Player
 from .schedule import ScheduleList
+from .standings import Standings
 
 _ = Translator("Hockey", __file__)
 log = logging.getLogger("red.trusty-cogs.hockey")

--- a/hockey/menu.py
+++ b/hockey/menu.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import re
 from datetime import datetime
-from typing import Any, List, Optional, Pattern
+from typing import Any, List, Optional, Pattern, Union
 
 import discord
 from redbot.core import commands
@@ -323,6 +323,19 @@ class PlayerPages(menus.ListPageSource):
         em = player.get_embed()
         em.set_footer(text=f"Page {menu.current_page + 1}/{self.get_max_pages()}")
         return em
+
+
+class SimplePages(menus.ListPageSource):
+    def __init__(self, pages: List[Union[discord.Embed, str]]):
+        super().__init__(pages, per_page=1)
+
+    def is_paginating(self):
+        return True
+
+    async def format_page(self, menu: menus.MenuPages, page):
+        if isinstance(page, discord.Embed):
+            page.set_footer(text=f"Page {menu.current_page + 1}/{self.get_max_pages()}")
+        return page
 
 
 class BaseMenu(menus.MenuPages, inherit_buttons=False):

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -17,8 +17,7 @@ class Pickems:
     Pickems object for handling votes on games for the day
     """
 
-    message: List[int]
-    messages: List[Tuple[int, int]]
+    messages: List[str]
     game_start: datetime
     home_team: str
     away_team: str
@@ -29,7 +28,6 @@ class Pickems:
 
     def __init__(self, **kwargs):
         super().__init__()
-        self.message = kwargs.get("message")
         self.messages = kwargs.get("messages", [])
         game_start = kwargs.get("game_start")
         self.game_start = datetime.strptime(game_start, "%Y-%m-%dT%H:%M:%SZ")
@@ -91,7 +89,6 @@ class Pickems:
 
     def to_json(self) -> dict:
         return {
-            "message": self.message,
             "messages": self.messages,
             "game_start": self.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "home_team": self.home_team,
@@ -106,7 +103,6 @@ class Pickems:
     def from_json(cls, data: dict):
         # log.debug(data)
         return cls(
-            message=data["message"],
             messages=data.get("messages", []),
             game_start=data["game_start"],
             home_team=data["home_team"],

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -136,8 +136,9 @@ class Pickems:
         if not game:
             return False
         if game.game_state == "Postponed":
-            # Postponed games we want to remove
-            return True
+            if game.game_start != self.game_start:
+                self.game_start = game.game_start
+            return False
         if game.home_score > game.away_score:
             self.winner = self.home_team
             return True
@@ -145,6 +146,9 @@ class Pickems:
             self.winner = self.away_team
             return True
         return False
+
+    async def get_game(self) -> Game:
+        return await Game.from_url(self.link)
 
     async def check_winner(self, game: Optional[Game] = None) -> bool:
         """

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from redbot.core.i18n import Translator
 
@@ -126,9 +126,10 @@ class Pickems:
         `True` if the winner has been set or the game is postponed
         `False` if the winner has not set and it's not time to clear it yet.
         """
+        log.debug(f"Setting winner for {repr(self)}")
         if not game:
             return False
-        if game.gatem_state == "Postponed":
+        if game.game_state == "Postponed":
             # Postponed games we want to remove
             return True
         if game.home_score > game.away_score:
@@ -139,7 +140,7 @@ class Pickems:
             return True
         return False
 
-    async def check_winner(self) -> bool:
+    async def check_winner(self, game: Optional[Game] = None) -> bool:
         """
         allow the pickems objects to check winner on their own
 
@@ -149,8 +150,11 @@ class Pickems:
         This realistically only gets called once all the games are done playing
         """
         after_game = datetime.utcnow() >= (self.game_start + timedelta(hours=2))
+        log.debug(f"Checking winner for {repr(self)}")
         if self.winner:
             return True
+        if game is not None:
+            return await self.set_pickem_winner(game)
         if self.link and after_game:
             game = await Game.from_url(self.link)
             return await self.set_pickem_winner(game)

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -17,7 +17,9 @@ class Pickems:
     Pickems object for handling votes on games for the day
     """
 
+    game_id: int
     messages: List[str]
+    guild: int
     game_start: datetime
     home_team: str
     away_team: str
@@ -28,7 +30,9 @@ class Pickems:
 
     def __init__(self, **kwargs):
         super().__init__()
+        self.game_id = kwargs.get("game_id")
         self.messages = kwargs.get("messages", [])
+        self.guild = kwargs.get("guild")
         game_start = kwargs.get("game_start")
         self.game_start = datetime.strptime(game_start, "%Y-%m-%dT%H:%M:%SZ")
         self.home_team = kwargs.get("home_team")
@@ -49,8 +53,10 @@ class Pickems:
         self.link = kwargs.get("link")
 
     def __repr__(self):
-        return "<Pickems home_team={0.home_team} away_team={0.away_team} name={0.name}>".format(
-            self
+        return (
+            "<Pickems game_id={0.game_id} name={0.name} guild={0.guild} winner={0.winner}>".format(
+                self
+            )
         )
 
     def compare_game(self, game: Game) -> bool:
@@ -89,7 +95,9 @@ class Pickems:
 
     def to_json(self) -> dict:
         return {
+            "game_id": self.game_id,
             "messages": self.messages,
+            "guild": self.guild,
             "game_start": self.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "home_team": self.home_team,
             "away_team": self.away_team,
@@ -103,7 +111,9 @@ class Pickems:
     def from_json(cls, data: dict):
         # log.debug(data)
         return cls(
+            game_id=data.get("game_id"),
             messages=data.get("messages", []),
+            guild=data.get("guild"),
             game_start=data["game_start"],
             home_team=data["home_team"],
             away_team=data["away_team"],

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -156,12 +156,12 @@ class Pickems:
         This realistically only gets called once all the games are done playing
         """
         after_game = datetime.utcnow() >= (self.game_start + timedelta(hours=2))
-        log.debug(f"Checking winner for {repr(self)}")
         if self.winner:
             return True
         if game is not None:
             return await self.set_pickem_winner(game)
         if self.link and after_game:
+            log.debug(f"Checking winner for {repr(self)}")
             game = await Game.from_url(self.link)
             return await self.set_pickem_winner(game)
         return False

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -1,11 +1,8 @@
-import asyncio
 import logging
 from datetime import datetime, timedelta
+from typing import List, Tuple
 
-import aiohttp
-import discord
 from redbot.core.i18n import Translator
-from redbot.core.utils import AsyncIter
 
 from .constants import TEAMS
 from .errors import NotAValidTeamError, UserHasVotedError, VotingHasEndedError
@@ -20,8 +17,8 @@ class Pickems:
     Pickems object for handling votes on games for the day
     """
 
-    message: list
-    channel: list
+    message: List[int]
+    messages: List[Tuple[int, int]]
     game_start: datetime
     home_team: str
     away_team: str
@@ -33,7 +30,7 @@ class Pickems:
     def __init__(self, **kwargs):
         super().__init__()
         self.message = kwargs.get("message")
-        self.channel = kwargs.get("channel")
+        self.messages = kwargs.get("messages", [])
         game_start = kwargs.get("game_start")
         self.game_start = datetime.strptime(game_start, "%Y-%m-%dT%H:%M:%SZ")
         self.home_team = kwargs.get("home_team")
@@ -54,7 +51,16 @@ class Pickems:
         self.link = kwargs.get("link")
 
     def __repr__(self):
-        return "<Pickems home_team={0.home_team} away_team={0.away_team} name={0.name} >".format(self)
+        return "<Pickems home_team={0.home_team} away_team={0.away_team} name={0.name} >".format(
+            self
+        )
+
+    def compare_game(self, game: Game) -> bool:
+        return (
+            self.home_team == game.home_team
+            and self.away_team == game.away_team
+            and self.game_start == game.game_start
+        )
 
     def add_vote(self, user_id, team):
         time_now = datetime.utcnow()
@@ -83,308 +89,10 @@ class Pickems:
         if str(user_id) not in self.votes:
             self.votes[str(user_id)] = team_choice
 
-    @staticmethod
-    def pickems_name(game):
-        return f"{game.away_abr}@{game.home_abr}-{game.game_start.month}-{game.game_start.day}"
-
-    async def set_pickem_winner(self, game):
-        """
-        Sets the pickem object winner from game object
-        """
-        if not game:
-            return self
-        if game.home_score > game.away_score:
-            self.winner = self.home_team
-        if game.away_score > game.home_score:
-            self.winner = self.away_team
-        return self
-
-    async def check_winner(self):
-        """
-        allow the pickems objects to check winner on their own
-        """
-        return self
-        after_game = datetime.utcnow() >= (self.game_start + timedelta(hours=3))
-        if self.winner:
-            return self
-        if self.link and after_game:
-            game = await Game.from_url(self.link)
-            return await self.set_pickem_winner(game)
-        return self
-
-        games_list = await Game.get_games(self.home_team, self.game_start, self.game_start)
-        if len(games_list) == 0 and self.name:
-            log.error(f"{self.name} Pickems game could not be found, was it rescheduled?")
-        elif len(games_list) == 1:
-            self.link = games_list[0].link
-            log.debug("Found a pickems game, setting link and winner")
-            return await self.set_pickem_winner(games_list[0])
-        return self
-
-    @staticmethod
-    async def find_pickems_object(bot, game):
-        """
-        Returns a list of all pickems on the bot for that game
-        """
-        return_pickems = []
-        new_name = f"{game.away_abr}@{game.home_abr}-{game.game_start.month}-{game.game_start.day}"
-        for guild_id, pickems in bot.get_cog("Hockey").all_pickems.items():
-            guild = bot.get_guild(int(guild_id))
-            if guild is None:
-                continue
-            if pickems is None:
-                pickems = []
-            if new_name in pickems:
-                return_pickems.append(pickems[new_name])
-
-        return return_pickems
-
-    @staticmethod
-    async def set_guild_pickem_winner(bot, game):
-        for guild_id, pickems in bot.get_cog("Hockey").all_pickems.items():
-            guild = bot.get_guild(int(guild_id))
-            if guild is None:
-                continue
-            if pickems is None:
-                pickems = {}
-            pickem_name = Pickems.pickems_name(game)
-            if pickem_name in pickems:
-                old_pickem = bot.get_cog("Hockey").all_pickems[str(guild_id)][pickem_name]
-                new_pickem = await old_pickem.set_pickem_winner(game)
-                bot.get_cog("Hockey").all_pickems[str(guild_id)][pickem_name] = new_pickem
-
-    @staticmethod
-    async def create_pickem_object(bot, guild, message, channel, game):
-        """
-        Checks to see if a pickem object is already created for the game
-        if not it creates one or adds the message, channel to the current ones
-        """
-        pickems = bot.get_cog("Hockey").all_pickems.get(str(guild.id), None)
-        new_name = Pickems.pickems_name(game)
-        if type(pickems) is list:
-            pickems = {}
-        if pickems is None:
-            bot.get_cog("Hockey").all_pickems[str((guild.id))] = {}
-            pickems = {}
-        old_pickem = None
-        old_name = None
-        for name, p in pickems.items():
-            if p.home_team == game.home_team and p.away_team == game.away_team:
-                if p.game_start == game.game_start:
-                    log.debug("Pickem already exists, adding channel")
-                    old_pickem = p
-                    old_name = name
-
-        if old_pickem is None:
-            pickems[new_name] = Pickems.from_json(
-                {
-                    "message": [message.id],
-                    "channel": [channel.id],
-                    "game_start": game.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "home_team": game.home_team,
-                    "away_team": game.away_team,
-                    "votes": {},
-                    "name": new_name,
-                    "winner": None,
-                    "link": game.link,
-                }
-            )
-
-            bot.get_cog("Hockey").all_pickems[str(guild.id)] = pickems
-            log.debug("creating new pickems")
-            log.debug(pickems)
-            return True
-        else:
-            # del pickems[old_name]
-            # old_pickem["message"].append(message.id)
-            # old_pickem["channel"].append(channel.id)
-            old_pickem.message.append(message.id)
-            old_pickem.channel.append(message.id)
-            if not old_pickem.link:
-                old_pickem.link = game.link
-            pickems[old_name] = old_pickem
-            # bot.get_cog("Hockey").all_pickems[str(guild.id)] = pickems
-            log.debug("using old pickems")
-            return False
-
-    @staticmethod
-    async def reset_weekly(bot):
-        # Reset the weekly leaderboard for all servers
-        config = bot.get_cog("Hockey").config
-        pickems_channels_to_delete = []
-        async for guild_id, data in AsyncIter((await config.all_guilds()).items(), steps=100):
-            guild = bot.get_guild(id=guild_id)
-            if guild is None:
-                continue
-            leaderboard = await config.guild(guild).leaderboard()
-            try:
-                current_guild_pickem_channels = await config.guild(guild).pickems_channels()
-                if current_guild_pickem_channels:
-                    pickems_channels_to_delete += current_guild_pickem_channels
-            except Exception:
-                log.error("Error adding channels to delete", exc_info=True)
-            if leaderboard is None:
-                leaderboard = {}
-            for user in leaderboard:
-                leaderboard[str(user)]["weekly"] = 0
-            await config.guild(guild).leaderboard.set(leaderboard)
-        try:
-            await Pickems.delete_pickems_channels(bot, pickems_channels_to_delete)
-        except Exception:
-            log.error("Error deleting pickems Channels", exc_info=True)
-
-    @staticmethod
-    async def create_pickems_channel(bot, name, guild):
-        msg = _(
-            "**Welcome to our daily Pick'ems challenge!  Below you will see today's games!"
-            "  Vote for who you think will win!  You get one point for each correct prediction."
-            "  We will be tracking points over the course "
-            "of the season and will be rewarding weekly,"
-            " worst and full-season winners!**\n\n"
-            "- Click the reaction for the team you think will win the day's match-up.\n"
-            "- Anyone who votes for both teams will have their "
-            "vote removed and will receive no points!\n\n\n\n"
-        )
-        config = bot.get_cog("Hockey").config
-        category = bot.get_channel(await config.guild(guild).pickems_category())
-        if not category:
-            return
-        try:
-            new_chn = await guild.create_text_channel(name, category=category)
-            await new_chn.send(msg)
-        except discord.errors.Forbidden:
-            await config.guild(guild).pickems_category.clear()
-            return None
-        return new_chn
-
-    @staticmethod
-    async def create_pickems_game_msg(bot, channel, game):
-        try:
-            new_msg = await channel.send(
-                "__**{} {}**__ @ __**{} {}**__".format(
-                    game.away_emoji, game.away_team, game.home_emoji, game.home_team
-                )
-            )
-        except Exception:
-            log.error("Error sending messages in pickems channel.")
-            return
-        # Create new pickems object for the game
-        try:
-            await Pickems.create_pickem_object(bot, channel.guild, new_msg, channel, game)
-        except Exception as e:
-            log.error("Error creating pickems Object.", exc_info=e)
-        if channel.permissions_for(channel.guild.me).add_reactions:
-            try:
-                await new_msg.add_reaction(game.away_emoji[2:-1])
-                await new_msg.add_reaction(game.home_emoji[2:-1])
-            except Exception:
-                log.debug("Error adding reactions")
-
-    @staticmethod
-    async def create_weekly_pickems_pages(bot, guilds, game_obj):
-        config = bot.get_cog("Hockey").config
-        session = bot.get_cog("Hockey").session
-        save_data = {}
-        today = datetime.now()
-        new_day = timedelta(days=1)
-        count = 0
-
-        while True:
-            chn_name = _("pickems-{month}-{day}").format(month=today.month, day=today.day)
-            data = []
-            for guild in guilds:
-                new_chn = await Pickems.create_pickems_channel(bot, chn_name, guild)
-                data.append(new_chn)
-
-            for new_channel in data:
-                if new_channel is None:
-                    continue
-                if new_channel.guild.id not in save_data:
-                    save_data[new_channel.guild.id] = [new_channel.id]
-                else:
-                    save_data[new_channel.guild.id].append(new_channel.id)
-
-            games_list = await game_obj.get_games(None, today, today, session)
-
-            for game in games_list:
-                for channel in data:
-                    if channel:
-                        await Pickems.create_pickems_game_msg(bot, channel, game)
-                        await asyncio.sleep(0.1)
-            today = today + new_day
-            count += 1
-            if today.weekday() == 6 or count == 7:
-                # just incase we end up in an infinite loop somehow
-                # can never be too careful with async coding
-                break
-        for guild_id, channels in save_data.items():
-            guild = bot.get_guild(guild_id)
-            if not guild:
-                continue
-            await config.guild(guild).pickems_channels.set(channels)
-
-    @staticmethod
-    async def delete_pickems_channels(bot, channels):
-        log.debug("Deleting pickems channels")
-        for channel_id in channels:
-            channel = bot.get_channel(channel_id)
-            if not channel:
-                continue
-            try:
-                await channel.delete()
-            except discord.errors.Forbidden:
-                pass
-            except Exception:
-                log.error("Error deleting old pickems channels", exc_info=True)
-
-    @staticmethod
-    async def tally_leaderboard(bot):
-        """
-        This should be where the pickems is removed and tallies are added
-        to the leaderboard
-        """
-        config = bot.get_cog("Hockey").config
-
-        async for guild_id, pickem_list in AsyncIter(bot.get_cog("Hockey").all_pickems.items(), steps=100):
-            guild = bot.get_guild(id=int(guild_id))
-            if guild is None:
-                continue
-            try:
-                to_remove = []
-                async for name, pickems in AsyncIter(pickem_list.items(), steps=50):
-                    if pickems.winner is not None:
-                        to_remove.append(name)
-                        leaderboard = await config.guild(guild).leaderboard()
-                        if leaderboard is None:
-                            leaderboard = {}
-                        for user, choice in pickems.votes.items():
-                            if str(user) not in leaderboard:
-                                leaderboard[str(user)] = {"season": 0, "weekly": 0, "total": 0}
-                            if choice == pickems.winner:
-                                if str(user) not in leaderboard:
-                                    leaderboard[str(user)] = {"season": 1, "weekly": 1, "total": 0}
-                                else:
-                                    leaderboard[str(user)]["season"] += 1
-                                    leaderboard[str(user)]["weekly"] += 1
-                            if "total" not in leaderboard[str(user)]:
-                                leaderboard[str(user)]["total"] = 0
-                            leaderboard[str(user)]["total"] += 1
-                        await config.guild(guild).leaderboard.set(leaderboard)
-                for name in to_remove:
-                    try:
-                        del bot.get_cog("Hockey").all_pickems[str(guild_id)][name]
-                    except Exception:
-                        log.error("Error removing pickems from memory", exc_info=True)
-                # await config.guild(guild).pickems.set(
-                # [p.to_json() for p in pickem_list if p.winner is None]
-                # )
-            except Exception:
-                log.exception(f"Error tallying leaderboard in {guild.name}")
-
     def to_json(self) -> dict:
         return {
             "message": self.message,
-            "channel": self.channel,
+            "messages": self.messages,
             "game_start": self.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "home_team": self.home_team,
             "away_team": self.away_team,
@@ -399,7 +107,7 @@ class Pickems:
         # log.debug(data)
         return cls(
             message=data["message"],
-            channel=data["channel"],
+            messages=data.get("messages", []),
             game_start=data["game_start"],
             home_team=data["home_team"],
             away_team=data["away_team"],
@@ -408,3 +116,42 @@ class Pickems:
             winner=data.get("winner", None),
             link=data.get("link", None),
         )
+
+    async def set_pickem_winner(self, game: Game) -> bool:
+        """
+        Sets the pickem object winner from game object
+
+        Returns
+        -------
+        `True` if the winner has been set or the game is postponed
+        `False` if the winner has not set and it's not time to clear it yet.
+        """
+        if not game:
+            return False
+        if game.gatem_state == "Postponed":
+            # Postponed games we want to remove
+            return True
+        if game.home_score > game.away_score:
+            self.winner = self.home_team
+            return True
+        elif game.away_score > game.home_score:
+            self.winner = self.away_team
+            return True
+        return False
+
+    async def check_winner(self) -> bool:
+        """
+        allow the pickems objects to check winner on their own
+
+        wrapper around set_pickems_winner method to pull the game object
+        and return true or false depending on the state of the game
+
+        This realistically only gets called once all the games are done playing
+        """
+        after_game = datetime.utcnow() >= (self.game_start + timedelta(hours=2))
+        if self.winner:
+            return True
+        if self.link and after_game:
+            game = await Game.from_url(self.link)
+            return await self.set_pickem_winner(game)
+        return False

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -18,6 +18,7 @@ class Pickems:
     """
 
     game_id: int
+    game_state: str
     messages: List[str]
     guild: int
     game_start: datetime
@@ -31,10 +32,10 @@ class Pickems:
     def __init__(self, **kwargs):
         super().__init__()
         self.game_id = kwargs.get("game_id")
+        self.game_state = kwargs.get("game_state")
         self.messages = kwargs.get("messages", [])
         self.guild = kwargs.get("guild")
-        game_start = kwargs.get("game_start")
-        self.game_start = datetime.strptime(game_start, "%Y-%m-%dT%H:%M:%SZ")
+        self.game_start = kwargs.get("game_start")
         self.home_team = kwargs.get("home_team")
         self.away_team = kwargs.get("away_team")
         self.votes = kwargs.get("votes")
@@ -54,10 +55,9 @@ class Pickems:
 
     def __repr__(self):
         return (
-            "<Pickems game_id={0.game_id} name={0.name} guild={0.guild} winner={0.winner}>".format(
-                self
-            )
-        )
+            "<Pickems game_id={0.game_id} game_state={0.game_state} "
+            "name={0.name} guild={0.guild} winner={0.winner}>"
+        ).format(self)
 
     def compare_game(self, game: Game) -> bool:
         return (
@@ -96,6 +96,7 @@ class Pickems:
     def to_json(self) -> dict:
         return {
             "game_id": self.game_id,
+            "game_state": self.game_state,
             "messages": self.messages,
             "guild": self.guild,
             "game_start": self.game_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -112,9 +113,10 @@ class Pickems:
         # log.debug(data)
         return cls(
             game_id=data.get("game_id"),
+            game_state=data.get("game_state"),
             messages=data.get("messages", []),
             guild=data.get("guild"),
-            game_start=data["game_start"],
+            game_start=datetime.strptime(data["game_start"], "%Y-%m-%dT%H:%M:%SZ"),
             home_team=data["home_team"],
             away_team=data["away_team"],
             votes=data["votes"],

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -49,7 +49,7 @@ class Pickems:
         self.link = kwargs.get("link")
 
     def __repr__(self):
-        return "<Pickems home_team={0.home_team} away_team={0.away_team} name={0.name} >".format(
+        return "<Pickems home_team={0.home_team} away_team={0.away_team} name={0.name}>".format(
             self
         )
 

--- a/hockey/pickems.py
+++ b/hockey/pickems.py
@@ -1,4 +1,6 @@
+from __future__ import annotations
 import logging
+import discord
 from datetime import datetime, timedelta
 from typing import List, Tuple, Optional
 
@@ -66,7 +68,7 @@ class Pickems:
             and self.game_start == game.game_start
         )
 
-    def add_vote(self, user_id, team):
+    def add_vote(self, user_id: int, team: discord.Emoji) -> None:
         time_now = datetime.utcnow()
 
         team_choice = None
@@ -109,7 +111,7 @@ class Pickems:
         }
 
     @classmethod
-    def from_json(cls, data: dict):
+    def from_json(cls, data: dict) -> Pickems:
         # log.debug(data)
         return cls(
             game_id=data.get("game_id"),

--- a/hockey/player.py
+++ b/hockey/player.py
@@ -1,15 +1,14 @@
-import aiohttp
 import json
 import logging
-import discord
-
 from dataclasses import dataclass
-from typing import Optional, Literal, Union
-from tabulate import tabulate
 from datetime import datetime
+from typing import Literal, Optional, Union
 
+import aiohttp
+import discord
 from redbot.core.i18n import Translator
 from redbot.core.utils.chat_formatting import box
+from tabulate import tabulate
 
 from .constants import BASE_URL, HEADSHOT_URL, TEAMS
 

--- a/hockey/player.py
+++ b/hockey/player.py
@@ -317,8 +317,8 @@ class Player:
         log.debug(url)
         log.debug(season)
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(url) as resp:
                     data = await resp.json()
         else:
             async with session.get(url) as resp:
@@ -361,8 +361,8 @@ class Player:
     async def from_id(cls, player_id: int, session: Optional[aiohttp.ClientSession] = None):
         url = f"https://records.nhl.com/site/api/player/{player_id}"
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(url) as resp:
                     data = await resp.json()
         else:
             async with session.get(url) as resp:
@@ -416,8 +416,8 @@ class Skater(Player):
         log.debug(url)
         log.debug(season)
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(url) as resp:
                     data = await resp.json()
         else:
             async with session.get(url) as resp:
@@ -629,8 +629,8 @@ class Goalie(Player):
         log.debug(url)
         log.debug(season)
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(url) as resp:
                     data = await resp.json()
         else:
             async with session.get(url) as resp:

--- a/hockey/player.py
+++ b/hockey/player.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
@@ -238,7 +239,7 @@ class Player:
                         name
                         + f"{self.height//12}' {self.height%12}\" / {int(self.height * 2.54)} cm\n"
                     )
-                elif attr == "birth_date":
+                elif attr == "birth_date" and self.birth_date is not None:
                     years = int(
                         (datetime.now() - datetime.strptime(self.birth_date, "%Y-%m-%d")).days
                         / 365.25
@@ -312,7 +313,7 @@ class Player:
 
     async def get_full_stats(
         self, season: Optional[str], session: Optional[aiohttp.ClientSession] = None
-    ):
+    ) -> Union[Player, Goalie, Skater]:
         url = f"https://statsapi.web.nhl.com/api/v1/people/{self.id}/stats?stats=yearByYear"
         log.debug(url)
         log.debug(season)
@@ -358,7 +359,7 @@ class Player:
         return f"https://www.capfriendly.com/players/{self.full_name_url()}"
 
     @classmethod
-    async def from_id(cls, player_id: int, session: Optional[aiohttp.ClientSession] = None):
+    async def from_id(cls, player_id: int, session: Optional[aiohttp.ClientSession] = None) -> Player:
         url = f"https://records.nhl.com/site/api/player/{player_id}"
         if session is None:
             async with aiohttp.ClientSession() as new_session:
@@ -409,7 +410,7 @@ class Skater(Player):
 
     async def get_full_stats(
         self, season: Optional[str], session: Optional[aiohttp.ClientSession] = None
-    ):
+    ) -> Union[Skater, SkaterPlayoffs]:
         url = (
             f"https://statsapi.web.nhl.com/api/v1/people/{self.id}/stats?stats=yearByYearPlayoffs"
         )
@@ -622,7 +623,7 @@ class Goalie(Player):
 
     async def get_full_stats(
         self, season: Optional[str], session: Optional[aiohttp.ClientSession] = None
-    ):
+    ) -> Union[Goalie, GoaliePlayoffs]:
         url = (
             f"https://statsapi.web.nhl.com/api/v1/people/{self.id}/stats?stats=yearByYearPlayoffs"
         )

--- a/hockey/schedule.py
+++ b/hockey/schedule.py
@@ -177,6 +177,7 @@ class ScheduleList(menus.PageSource):
         self.team = kwargs.get("team", [])
         self._last_searched = ""
         self._session = kwargs.get("session")
+        self.timezone = kwargs.get("timezone")
 
     @property
     def index(self):
@@ -257,11 +258,12 @@ class ScheduleList(menus.PageSource):
                 )
             else:
                 if self.team == []:
-                    game_time = utc_to_local(game_start, TEAMS[home_team]["timezone"])
+                    timezone = self.timezone or TEAMS[home_team]["timezone"]
+                    game_time = utc_to_local(game_start, timezone)
                     time_str = game_time.strftime("%I:%M %p %Z")
                 else:
-
-                    game_time = utc_to_local(game_start, TEAMS[self.team[0]]["timezone"])
+                    timezone = self.timezone or TEAMS[self.team[0]]["timezone"]
+                    game_time = utc_to_local(game_start, timezone)
                     time_str = game_time.strftime("%I:%M %p %Z")
                 msg += (
                     f"{game_state} - {away_emoji} {away_abr} @ "

--- a/hockey/schedule.py
+++ b/hockey/schedule.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, List
 
 import aiohttp
 import discord
@@ -19,27 +19,28 @@ log = logging.getLogger("red.trusty-cogs.hockey")
 
 class Schedule(menus.PageSource):
     def __init__(self, **kwargs):
-        self._yielded = 0
-        self._listing = None
-        self._index = 0
-        self._cache = []
-        self._checks = 0
-        self._last_page = 0
-        self.date = kwargs.get("date", utc_to_local(datetime.utcnow()))
-        self.limit = kwargs.get("limit", 10)
-        self.team = kwargs.get("team", None)
-        self._last_searched = ""
-        self._session = kwargs.get("session")
+        self._yielded: int = 0
+        self._index: int = 0
+        self._cache: List[dict] = []
+        self._checks: int = 0
+        self._last_page: int = 0
+        self.date: datetime = kwargs.get("date", utc_to_local(datetime.utcnow()))
+        self.limit: int = kwargs.get("limit", 10)
+        self.team: str = kwargs.get("team", None)
+        self._last_searched: str = ""
+        self._session: aiohttp.CLientSession = kwargs.get("session")
 
     @property
-    def index(self):
+    def index(self) -> int:
         return self._index
 
     @property
-    def last_page(self):
+    def last_page(self) -> int:
         return self._last_page
 
-    async def get_page(self, page_number, *, skip_next: bool = False, skip_prev: bool = False):
+    async def get_page(
+        self, page_number, *, skip_next: bool = False, skip_prev: bool = False
+    ) -> dict:
         # log.info(f"Cache size is {len(self._cache)}")
 
         if page_number < self.last_page:
@@ -58,7 +59,7 @@ class Schedule(menus.PageSource):
         self._last_page = page_number
         return page
 
-    async def format_page(self, menu: menus.MenuPages, game: dict):
+    async def format_page(self, menu: menus.MenuPages, game: dict) -> discord.Embed:
         async with aiohttp.ClientSession() as session:
             log.debug(BASE_URL + game["link"])
             async with session.get(BASE_URL + game["link"]) as resp:
@@ -67,7 +68,7 @@ class Schedule(menus.PageSource):
         # return {"content": f"{self.index+1}/{len(self._cache)}", "embed": await game_obj.make_game_embed()}
         return await game_obj.make_game_embed(True)
 
-    async def next(self, skip: bool = False):
+    async def next(self, skip: bool = False) -> dict:
         """
         Returns the next element from the list
 
@@ -90,7 +91,7 @@ class Schedule(menus.PageSource):
         # log.info(f"getting next data {len(self._cache)}")
         return self._cache[self.index]
 
-    async def prev(self, skip: bool = False):
+    async def prev(self, skip: bool = False) -> dict:
         """
         Returns the previous element from the list
 
@@ -114,13 +115,13 @@ class Schedule(menus.PageSource):
                 raise NoSchedule(e)
         return self._cache[self.index]
 
-    async def prepare(self):
+    async def prepare(self) -> None:
         try:
             await self._next_batch(date=self.date)
         except NoSchedule:
             pass
 
-    def is_paginating(self):
+    def is_paginating(self) -> bool:
         return True
 
     async def _next_batch(
@@ -131,7 +132,7 @@ class Schedule(menus.PageSource):
         end_date: Optional[datetime] = None,
         _next: bool = False,
         _prev: bool = False,
-    ):
+    ) -> List[dict]:
         """
         Actually grab the list of games.
         """
@@ -166,28 +167,29 @@ class Schedule(menus.PageSource):
 
 class ScheduleList(menus.PageSource):
     def __init__(self, **kwargs):
-        self._yielded = 0
-        self._listing = None
-        self._index = 0
-        self._cache = []
-        self._checks = 0
-        self._last_page = 0
-        self.date = kwargs.get("date", utc_to_local(datetime.utcnow()))
-        self.limit = kwargs.get("limit", 10)
-        self.team = kwargs.get("team", [])
-        self._last_searched = ""
-        self._session = kwargs.get("session")
-        self.timezone = kwargs.get("timezone")
+        self._yielded: int = 0
+        self._index: int = 0
+        self._cache: List[dict] = []
+        self._checks: int = 0
+        self._last_page: int = 0
+        self.date: datetime = kwargs.get("date", utc_to_local(datetime.utcnow()))
+        self.limit: int = kwargs.get("limit", 10)
+        self.team: List[str] = kwargs.get("team", [])
+        self._last_searched: str = ""
+        self._session: aiohttp.ClientSession = kwargs.get("session")
+        self.timezone: str = kwargs.get("timezone")
 
     @property
-    def index(self):
+    def index(self) -> int:
         return self._index
 
     @property
-    def last_page(self):
+    def last_page(self) -> int:
         return self._last_page
 
-    async def get_page(self, page_number, *, skip_next: bool = False, skip_prev: bool = False):
+    async def get_page(
+        self, page_number, *, skip_next: bool = False, skip_prev: bool = False
+    ) -> List[dict]:
         # log.info(f"Cache size is {len(self._cache)}")
 
         if page_number < self.last_page:
@@ -206,7 +208,7 @@ class ScheduleList(menus.PageSource):
         self._last_page = page_number
         return page
 
-    async def format_page(self, menu: menus.MenuPages, games: dict):
+    async def format_page(self, menu: menus.MenuPages, games: List[dict]) -> discord.Embed:
         states = {
             "Preview": "\N{LARGE RED CIRCLE}",
             "Live": "\N{LARGE GREEN CIRCLE}",
@@ -297,7 +299,7 @@ class ScheduleList(menus.PageSource):
         # return {"content": f"{self.index+1}/{len(self._cache)}", "embed": await game_obj.make_game_embed()}
         return em
 
-    async def next(self, skip: bool = False):
+    async def next(self, skip: bool = False) -> List[dict]:
         """
         Returns the next element from the list
 
@@ -322,7 +324,7 @@ class ScheduleList(menus.PageSource):
         # log.info(f"getting next data {len(self._cache)}")
         return self._cache
 
-    async def prev(self, skip: bool = False):
+    async def prev(self, skip: bool = False) -> List[dict]:
         """
         Returns the previous element from the list
 
@@ -365,7 +367,7 @@ class ScheduleList(menus.PageSource):
         end_date: Optional[datetime] = None,
         _next: bool = False,
         _prev: bool = False,
-    ):
+    ) -> List[dict]:
         """
         Actually grab the list of games.
         """

--- a/hockey/schedule.py
+++ b/hockey/schedule.py
@@ -1,12 +1,12 @@
-import discord
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
 import aiohttp
+import discord
 from redbot.core.i18n import Translator
-from redbot.vendored.discord.ext import menus
 from redbot.core.utils.chat_formatting import pagify
+from redbot.vendored.discord.ext import menus
 
 from .constants import BASE_URL, TEAMS
 from .errors import NoSchedule

--- a/hockey/standings.py
+++ b/hockey/standings.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import logging
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple
 
 import aiohttp
 import discord
@@ -93,7 +94,7 @@ class Standings:
     async def get_team_standings(
         style: str,
         session: Optional[aiohttp.ClientSession] = None,
-    ):
+    ) -> List[Standings]:
         """
         Creates a list of standings when given a particular style
         accepts Division names, Conference names, and Team names
@@ -110,7 +111,7 @@ class Standings:
         return await Standings.get_team_standings_from_data(style, data)
 
     @staticmethod
-    async def get_team_standings_from_data(style: str, data: dict):
+    async def get_team_standings_from_data(style: str, data: dict) -> Tuple[List[Standings], int]:
 
         if style.lower() in CONFERENCES:
             # Leaving this incase it comes back
@@ -167,7 +168,7 @@ class Standings:
             return all_teams, index
 
     @staticmethod
-    async def post_automatic_standings(bot):
+    async def post_automatic_standings(bot) -> None:
         """
         Automatically update a standings embed with the latest stats
         run when new games for the day is updated
@@ -229,7 +230,7 @@ class Standings:
     @staticmethod
     async def edit_standings_message(
         embed: discord.Embed, guild: discord.Guild, message: discord.Message, config: Config
-    ):
+    ) -> None:
         try:
             await message.edit(embed=embed)
         except (discord.errors.NotFound, discord.errors.Forbidden):
@@ -241,7 +242,7 @@ class Standings:
             log.exception(f"Error editing standings message in {repr(guild)}")
 
     @classmethod
-    async def from_json(cls, data: dict, division: str, conference: str):
+    async def from_json(cls, data: dict, division: str, conference: str) -> Standings:
         if "streak" in data:
             streak_number = data["streak"]["streakNumber"]
             streak_type = data["streak"]["streakType"]
@@ -269,7 +270,7 @@ class Standings:
         )
 
     @staticmethod
-    async def all_standing_embed(post_standings):
+    async def all_standing_embed(post_standings: List[Standings]) -> discord.Embed:
         """
         Builds the standing embed when all TEAMS are selected
         """
@@ -302,7 +303,7 @@ class Standings:
         return em
 
     @staticmethod
-    async def make_division_standings_embed(team_stats):
+    async def make_division_standings_embed(team_stats: List[Standings]) -> discord.Embed:
         em = discord.Embed()
         msg = ""
         # timestamp = datetime.strptime(team_stats[0].last_updated, "%Y-%m-%dT%H:%M:%SZ")
@@ -329,7 +330,7 @@ class Standings:
         return em
 
     @staticmethod
-    async def make_conference_standings_embed(team_stats):
+    async def make_conference_standings_embed(team_stats: List[Standings]) -> discord.Embed:
         em = discord.Embed()
         msg = ""
         newteam_stats = sorted(team_stats, key=lambda k: int(k.conference_rank))
@@ -363,7 +364,7 @@ class Standings:
         return em
 
     @staticmethod
-    async def make_team_standings_embed(team_stats):
+    async def make_team_standings_embed(team_stats: Standings) -> discord.Embed:
         em = discord.Embed()
         em.set_author(
             name="# {} {}".format(team_stats.league_rank, team_stats.name),
@@ -372,15 +373,15 @@ class Standings:
         )
         em.colour = int(TEAMS[team_stats.name]["home"].replace("#", ""), 16)
         em.set_thumbnail(url=TEAMS[team_stats.name]["logo"])
-        em.add_field(name="Division", value="# " + team_stats.division_rank)
-        em.add_field(name="Conference", value="# " + team_stats.conference_rank)
-        em.add_field(name="Wins", value=team_stats.wins)
-        em.add_field(name="Losses", value=team_stats.losses)
-        em.add_field(name="OT", value=team_stats.ot)
-        em.add_field(name="Points", value=team_stats.pts)
-        em.add_field(name="Games Played", value=team_stats.gp)
-        em.add_field(name="Goals Scored", value=team_stats.goals)
-        em.add_field(name="Goals Against", value=team_stats.gaa)
+        em.add_field(name="Division", value=f"# {team_stats.division_rank}")
+        em.add_field(name="Conference", value=f"# {team_stats.conference_rank}")
+        em.add_field(name="Wins", value=str(team_stats.wins))
+        em.add_field(name="Losses", value=str(team_stats.losses))
+        em.add_field(name="OT", value=str(team_stats.ot))
+        em.add_field(name="Points", value=str(team_stats.pts))
+        em.add_field(name="Games Played", value=str(team_stats.gp))
+        em.add_field(name="Goals Scored", value=str(team_stats.goals))
+        em.add_field(name="Goals Against", value=str(team_stats.gaa))
         em.add_field(
             name="Current Streak",
             value="{} {}".format(team_stats.streak, team_stats.streak_type),
@@ -391,7 +392,7 @@ class Standings:
         return em
 
     @staticmethod
-    async def build_standing_embed(post_list, page=0):
+    async def build_standing_embed(post_list: List[Standings], page=0) -> discord.Embed:
         """
         Builds the standings type based on number of items in the list
         """

--- a/hockey/standings.py
+++ b/hockey/standings.py
@@ -1,10 +1,9 @@
 import logging
 from datetime import datetime
-from typing import Optional, Literal, List
+from typing import List, Literal, Optional
 
 import aiohttp
 import discord
-
 from redbot import VersionInfo, version_info
 from redbot.core.utils import AsyncIter
 

--- a/hockey/standings.py
+++ b/hockey/standings.py
@@ -101,8 +101,8 @@ class Standings:
         style in the list
         """
         if session is None:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(BASE_URL + "/api/v1/standings") as resp:
+            async with aiohttp.ClientSession() as new_session:
+                async with new_session.get(BASE_URL + "/api/v1/standings") as resp:
                     data = await resp.json()
         else:
             async with session.get(BASE_URL + "/api/v1/standings") as resp:


### PR DESCRIPTION

[Hockey] 3.0.0
This restructures hockey to utilize an abstract base class and reorganizes pickems to be more maintainable.
- All pickems data is migrated to a new settings file outside the main hockey file. This should free up memory constraints when looking for guild data in game and goal updates.
- Pickems logic isolated into two files
- ABC class created for all public methods
- Missing typehints added
- pickems is supposed to remove the old emoji the user had not the new one 
 - Add pickemsannounce command to send an update about pickems to all created channels
- Restructure `[p]nhldev cogstats` to display more information about how the cog is being used across all servers.
- Add easier names for all dev commands
- Make some i18n strings easier to work with
- Remove i18n from more logging messages
- change all `checks` to `commands`
- Use more sane `channelid-messageid` format for pickems lookup. The tuple would end up converting to a list from config which is no longer mutable.
- Move pickems commands into hockeypickems.py. This requires setting the `[p]nhlset` command inside the abstract base class and rather than treating it as an abstractmethod it's a full method that hockeyset.py and hockeypickems.py utilize.
 - Add checks for GDC creation for too many channels and missing permissions
- Handle situations where a message may be published and we want to edit it causing the main loops to wait for publish rate limits to finish before continuing
- Consume rate limits per guild for creating pickems channels
- Add game start strings to pickems messages
- Add server settings for pickems timezone usage
- Add server settings for schedule and game day channel timezones
- change from version info to schema_version for transferring config settings
- Add timezone setting commands under `[p]nhlset timezone` and `[p]nhlset pickems timezone`
- Add timezone listing setting under `[p]nhlset timezone list`
- Add option to set custom message added to pickems creation messages
- Add ability to edit pickems channel messages to display the winner of the game
- Use and store game ID instead of a custom name for each pickems since some games might have been postponed and we don't want to necessarily lose the votes people already have.
- Remove unused config entries for pickems in normal hockey config
- Don't convert old pickems values at all since this is considered a breaking change and I can't easily convert any old pickems to the new format
- Don't loop games until _ready is set so we don't try tallying pickems votes until after the data has been loaded properly
- Store guild ID in pickems just incase I need it later
- Pickems links will now always be present no need to check
- Check if the game_start has changed despite the same game ID, we can edit the pickems object if this is different since this will not never be the same if the game is postponed
- Fix error in checking if session was passed to certain objects resulting in session being closed
- Display games as postponed if we don't find out until day-of
- Don't block the game loop just because we want to edit a message and only attempt to edit/change a pickems once
- Use correct config for weekly check
- Add ability to award credits per-pickem and for weekly top voters per server
- Allow reward information to be added to pickems messages
