### PR TITLE
[NotSoBot] Fix vw command not working.

### DIFF
--- a/notsobot/notsobot.py
+++ b/notsobot/notsobot.py
@@ -992,7 +992,7 @@ class NotSoBot(commands.Cog):
         final.seek(0)
         file = discord.File(final, filename="vapewave.png")
         final.close()
-        return final, file_size
+        return file, file_size
 
     @commands.command(aliases=["vaporwave", "vape", "vapewave"])
     @commands.cooldown(2, 5)


### PR DESCRIPTION
Before when running the [p]vw command, it would error with `InvalidArgument: file parameter must be File`. It was trying to send the BytesIO instead of the discord.FIle object. 