### PR TITLE
[Starboard] Move initialize from setup to a task

### DIFF
--- a/starboard/__init__.py
+++ b/starboard/__init__.py
@@ -7,7 +7,6 @@ with open(Path(__file__).parent / "info.json") as fp:
     __red_end_user_data_statement__ = json.load(fp)["end_user_data_statement"]
 
 
-async def setup(bot):
+def setup(bot):
     cog = Starboard(bot)
     bot.add_cog(cog)
-    await cog.initialize()

--- a/starboard/events.py
+++ b/starboard/events.py
@@ -22,11 +22,13 @@ class StarboardEvents:
     bot: Red
     config: Config
     starboards: Dict[int, StarboardEntry]
+    ready: asyncio.Event()
 
     def __init__(self, bot):
         self.bot: Red
         self.config: Config
         self.starboards: Dict[int, Dict[str, StarboardEntry]]
+        self.ready: asyncio.Event()
 
     async def _build_starboard_info(self, ctx: commands.Context, starboard: StarboardEntry):
         channel_perms = ctx.channel.permissions_for(ctx.guild.me)
@@ -243,14 +245,17 @@ class StarboardEvents:
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        await self.ready.wait()
         await self._update_stars(payload)
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
+        await self.ready.wait()
         await self._update_stars(payload, remove=payload.user_id)
 
     @commands.Cog.listener()
     async def on_raw_reaction_clear(self, payload: discord.RawReactionActionEvent) -> None:
+        await self.ready.wait()
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return


### PR DESCRIPTION
I've seen it taking over 2 minutes to put starboards config to cache, so on setup it was timing out on bot startup. I've also added a `ready` attribute to the cog, which is checked before executing any command of the cog, and also on events.