### PR TITLE
[Welcome] Confirmation message changes in `[p]welcomeset greeting channel`

### DIFF
--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -422,7 +422,7 @@ class Welcome(Events, commands.Cog):
         guild_settings = channel.id
         await self.config.guild(guild).CHANNEL.set(guild_settings)
         msg = _("I will now send welcome messages to {channel}").format(channel=channel.mention)
-        await channel.send(msg)
+        await ctx.send(msg)
 
     @welcomeset_greeting.command()
     async def test(self, ctx: commands.Context) -> None:


### PR DESCRIPTION
IMO, the confirmation message for this command should be sent to the invoker's channel, not to the newly set channel. I normally have to go to that channel and delete the message that was sent, so it's quite inconvenient sometimes.

Edit: This is what its like for `[p]welcomeset goodbye channel`.