### PR TITLE
[ExtendedModLog] fix pagified edited/deleted message content

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -368,7 +368,7 @@ class EventMixin:
                 channel=message_channel.mention,
             )
         if embed_links:
-            content = list(pagify(f"{message.author.mention}: {message.content}"))
+            content = list(pagify(f"{message.author.mention}: {message.content}", page_length=1000))
             embed = discord.Embed(
                 description=content.pop(0),
                 colour=await self.get_event_colour(guild, "message_delete"),
@@ -1251,7 +1251,7 @@ class EventMixin:
         time = datetime.datetime.utcnow()
         fmt = "%H:%M:%S"
         if embed_links:
-            content = list(pagify(f"{before.author.mention}: {before.content}"))
+            content = list(pagify(f"{before.author.mention}: {before.content}", page_length=1000))
             embed = discord.Embed(
                 description=content.pop(0),
                 colour=await self.get_event_colour(guild, "message_edit"),


### PR DESCRIPTION
Hi,

I saw extendedmodlog was silently erroring out for me when trying to log message deleted/edited content of 4000 chars. I gave a closer look and I saw the pagify function was making list of items of 2k chars each by default which errors out since embed fields have max char length of 1024 chars. This PR fixes that issue by setting `page_length` to 1000 in pagify function. I have tested my changes successfully on my local setup.

Attaching logs for reference:
Traceback received when trying to log deleted content:
```py
Ignoring exception in on_raw_message_delete

Traceback (most recent call last):
  File "/opt/lib/python3.9/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/opt/cogs/CogManager/cogs/extendedmodlog/eventmixin.py", line 315, in on_raw_message_delete_listener
    await self._cached_message_delete(

  File "/opt/cogs/CogManager/cogs/extendedmodlog/eventmixin.py", line 391, in _cached_message_delete
    await channel.send(embed=embed)
  File "/opt/lib/python3.9/site-packages/discord/abc.py", line 1065, in send
    data = await state.http.send_message(channel.id, content, tts=tts, embed=embed,
  File "/opt/lib/python3.9/site-packages/discord/http.py", line 254, in request
    raise HTTPException(r, data)
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embed.fields.0.value: Must be 1024 or fewer in length.
```

Traceback received when trying to log edited content:
```py
Ignoring exception in on_message_edit

Traceback (most recent call last):
  File "/opt/lib/python3.9/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/opt/cogs/CogManager/cogs/extendedmodlog/eventmixin.py", line 1271, in on_message_edit
    await channel.send(embed=embed)
  File "/opt/lib/python3.9/site-packages/discord/abc.py", line 1065, in send
    data = await state.http.send_message(channel.id, content, tts=tts, embed=embed,
  File "/opt/lib/python3.9/site-packages/discord/http.py", line 254, in request
    raise HTTPException(r, data)
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embed.fields.0.value: Must be 1024 or fewer in length.
```