### PR TITLE
[Serverstats] Add space on getroles output title

### DIFF
--- a/serverstats/serverstats.py
+++ b/serverstats/serverstats.py
@@ -1521,7 +1521,7 @@ class ServerStats(commands.Cog):
             if ctx.channel.permissions_for(ctx.me).embed_links:
                 embed = discord.Embed()
                 embed.description = page
-                embed.set_author(name=guild.name + _("Roles"), icon_url=guild.icon_url)
+                embed.set_author(name=f"{guild.name} " + _("Roles"), icon_url=guild.icon_url)
                 msg_list.append(embed)
             else:
                 msg_list.append(page)


### PR DESCRIPTION
Not sure if you want a version bump on this so I left it off. There was just a missing space on the title output for getroles.