### PR TITLE
[NotSoBot] Fix for glitch with jpeg image

### DIFF
--- a/notsobot/notsobot.py
+++ b/notsobot/notsobot.py
@@ -93,7 +93,7 @@ class NotSoBot(commands.Cog):
     """
 
     __author__ = ["NotSoSuper", "TrustyJAID"]
-    __version__ = "2.5.1"
+    __version__ = "2.5.2"
 
     def __init__(self, bot):
         self.bot = bot
@@ -1163,7 +1163,7 @@ class NotSoBot(commands.Cog):
 
     def do_glitch(self, b, amount, seed, iterations):
         img = Image.open(b)
-        is_gif = img.is_animated
+        is_gif = ((hasattr(img, "is_animated")) and (img.is_animated))
         if not is_gif:
             img = img.convert("RGB")
             b = BytesIO()


### PR DESCRIPTION
Using the glitch command with a jpeg image gave an AttributeError. This PR checks for that attribute (still present on GIF images) and reroutes appropriately.

```
c:\envs\joker3.4\lib\site-packages\discord\ext\commands\core.py:85 in wrapped
> 85 ret = await coro(*args, **kwargs)
C:\joker\cogs\CogManager\cogs\notsobot\notsobot.py:1231 in glitch
> 1231 file, file_size = await asyncio.wait_for(task, timeout=60)
C:\Program Files (x86)\Python38-32\lib\asyncio\tasks.py:483 in wait_for
> 483 return fut.result()
C:\Program Files (x86)\Python38-32\lib\concurrent\futures\thread.py:57 in run
> 57 result = self.fn(*self.args, **self.kwargs)
C:\joker\cogs\CogManager\cogs\notsobot\notsobot.py:1166 in do_glitch
> 1166 is_gif = img.is_animated
c:\envs\joker3.4\lib\site-packages\PIL\Image.py:541 in __getattr__
> 541 raise AttributeError(name)
AttributeError: is_animated
```
