### PR TITLE
Change deprecated `guild_id` in bot.allowed_by_whitelist_blacklist to `guild`

### DIFF
--- a/addimage/addimage.py
+++ b/addimage/addimage.py
@@ -144,7 +144,7 @@ class AddImage(commands.Cog):
             return await self.bot.allowed_by_whitelist_blacklist(
                 message.author,
                 who_id=message.author.id,
-                guild_id=message.guild.id,
+                guild=message.guild,
                 role_ids=[r.id for r in author.roles],
             )
         except AttributeError:

--- a/cleverbot/api.py
+++ b/cleverbot/api.py
@@ -155,7 +155,7 @@ class CleverbotAPI:
             return await self.bot.allowed_by_whitelist_blacklist(
                 message.author,
                 who_id=message.author.id,
-                guild_id=message.guild.id,
+                guild=message.guild,
                 role_ids=[r.id for r in message.author.roles],
             )
         except AttributeError:

--- a/translate/api.py
+++ b/translate/api.py
@@ -426,7 +426,7 @@ class GoogleTranslateAPI:
         """
         try:
             return await self.bot.allowed_by_whitelist_blacklist(
-                author, who_id=author.id, guild_id=guild.id, role_ids=[r.id for r in author.roles]
+                author, who_id=author.id, guild=guild, role_ids=[r.id for r in author.roles]
             )
         except AttributeError:
             if await self.bot.is_owner(author):


### PR DESCRIPTION
As the title says, `guild_id` in `bot.allowed_by_whitelist_blacklist()` is deprecated, since 3.4.8 actually.
> https://github.com/Cog-Creators/Red-DiscordBot/blob/2a25d7e7c1f1a82325059d06699cf50046c29d6c/redbot/core/bot.py#L717-L725