### PR TITLE
Translate - Re-order on_message checks

### DIFF
--- a/translate/api.py
+++ b/translate/api.py
@@ -416,9 +416,9 @@ class GoogleTranslateAPI:
             return
         if await self.bot.cog_disabled_in_guild(self, guild):
             return
-        if not await self.check_bw_list(guild, channel, author):
-            return
         if not await self.bot.message_eligible_as_command(message):
+            return
+        if not await self.check_bw_list(guild, channel, author):
             return
         flag_search = FLAG_REGEX.search(message.clean_content)
         if not flag_search:


### PR DESCRIPTION
`check_bw_list` must be done after `bot.message_eligible_as_command`, because the first method looks into channel object, which might be a `PartialMessageable` which in that case is returned as a False by the second method.