### PR TITLE
[loaddev] support development branch

### DIFF
--- a/loaddev/info.json
+++ b/loaddev/info.json
@@ -8,7 +8,7 @@
     "hidden": true,
     "install_msg": "This allows cores dev module to be loaded dynamically. Not recommended for production use.",
     "max_bot_version": "0.0.0",
-    "min_bot_version": "3.5.0",
+    "min_bot_version": "3.5.0.dev1",
     "min_python_version": [
         3,
         7,


### PR DESCRIPTION
Fix for:
`This cog requires different Red version than you currently have (3.5.0.dev311+gdb531f7c): loaddev (Minimum: 3.5.0)`