### PR TITLE
Extendedmodlog - Fix member/role no longer existing in get_permission_change

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -756,7 +756,10 @@ class EventMixin:
             entity_obj = before.guild.get_role(int(entity))
             if not entity_obj:
                 entity_obj = before.guild.get_member(int(entity))
-            name = entity_obj.mention if embed_links else entity_obj.name
+            if entity_obj is not None:
+                name = entity_obj.mention if embed_links else entity_obj.name
+            else:
+                name = entity
             if entity not in after_perms:
                 perp, reason = await self.get_audit_log_reason(
                     guild, before, discord.AuditLogAction.overwrite_delete
@@ -792,7 +795,10 @@ class EventMixin:
             entity_obj = after.guild.get_role(int(entity))
             if not entity_obj:
                 entity_obj = after.guild.get_member(int(entity))
-            name = entity_obj.mention if embed_links else entity_obj.name
+            if entity_obj is not None:
+                name = entity_obj.mention if embed_links else entity_obj.name
+            else:
+                name = entity
             if entity not in before_perms:
                 perp, reason = await self.get_audit_log_reason(
                     guild, before, discord.AuditLogAction.overwrite_update


### PR DESCRIPTION
In some cases the "entity" no longer exists when this gets processed, this takes account of that. Instead of sending the mention or name, it will just send the ID.