### PR TITLE
[weather] API key instructions and error handling

### DIFF
--- a/weather/api.py
+++ b/weather/api.py
@@ -234,6 +234,8 @@ class Geocoding:
         else:
             async with session.get(url, params=params) as resp:
                 data = await resp.json()
+        if "cod" in data and data["cod"] != "200":
+            raise APIError(data["message"])
         return [cls.from_json(i) for i in data]
 
     @classmethod
@@ -260,6 +262,8 @@ class Geocoding:
         else:
             async with session.get(url, params=params) as resp:
                 data = await resp.json()
+        if "cod" in data and data["cod"] != "200":
+            raise APIError(data["message"])
         return [cls.from_json(i) for i in data]
 
 
@@ -737,10 +741,10 @@ class OneCall:
                     data = await resp.json()
         else:
             async with session.get(url, params=params) as resp:
-                if resp.status != 200:
-                    raise APIError()
                 data = await resp.json()
         log.debug(data)
+        if "cod" in data and data["cod"] != "200":
+            raise APIError(data["message"])
         return cls.from_json(data, units, name, state, country)
 
     def embed(

--- a/weather/menus.py
+++ b/weather/menus.py
@@ -52,7 +52,7 @@ class WeatherPages(menus.ListPageSource):
                     session=view.session,
                 )
             except APIError as e:
-                return e
+                return str(e)
         else:
             we = self._last_we
         if self._last_coords is None:

--- a/weather/weather.py
+++ b/weather/weather.py
@@ -265,14 +265,14 @@ class Weather(commands.Cog):
         2. Create an account.
         3. go to https://home.openweathermap.org/api_keys
         4. Enter an API key name and click Generate
-        5. Copy the key and run `[p]set api openweather api_key YOUR_API_KEY_HERE`
+        5. Copy the key and run `[p]set api openweathermap api_key YOUR_API_KEY_HERE`
         """
         msg = _(
             "1. go to https://openweathermap.org\n"
             "2. Create an account.\n"
             "3. go to https://home.openweathermap.org/api_keys\n"
             "4. Enter an API key name and click Generate\n"
-            "5. Copy the key and run `{prefix}set api openweather api_key YOUR_API_KEY_HERE`"
+            "5. Copy the key and run `{prefix}set api openweathermap api_key YOUR_API_KEY_HERE`"
         ).format(prefix=ctx.clean_prefix)
         keys = {"api_key": ""}
         view = SetApiView("openweathermap", keys)

--- a/weather/weather.py
+++ b/weather/weather.py
@@ -266,13 +266,15 @@ class Weather(commands.Cog):
         3. go to https://home.openweathermap.org/api_keys
         4. Enter an API key name and click Generate
         5. Copy the key and run `[p]set api openweathermap api_key YOUR_API_KEY_HERE`
+        6. go to https://home.openweathermap.org/subscriptions and Subscribe to One Call by Call
         """
         msg = _(
             "1. go to https://openweathermap.org\n"
             "2. Create an account.\n"
             "3. go to https://home.openweathermap.org/api_keys\n"
             "4. Enter an API key name and click Generate\n"
-            "5. Copy the key and run `{prefix}set api openweathermap api_key YOUR_API_KEY_HERE`"
+            "5. Copy the key and run `{prefix}set api openweathermap api_key YOUR_API_KEY_HERE`\n"
+            "6. go to https://home.openweathermap.org/subscriptions and Subscribe to One Call by Call\n"
         ).format(prefix=ctx.clean_prefix)
         keys = {"api_key": ""}
         view = SetApiView("openweathermap", keys)


### PR DESCRIPTION
This PR makes two corrections to the `weather` cog API key instructions and improves API key error handling. The patch has been tested on my dev bot instance running V3/develop branch both with an invalid key and a valid key with a One Call subscription.

- the name of the API key is `openweathermap`, not `openweather`; fixed in the `[p]weather set creds` instructions
- One Call subscription is now needed for the `onecall` endpoint to work; fixed by this amendment to the instructions:
```
6. go to https://home.openweathermap.org/subscriptions and Subscribe to the Base plan
```
- when calling any endpoint does not result in 200 status (e.g. 401 due to a missing One Call subscription), the error text is passed back to the user, e.g.
> Invalid API key. Please see https://openweathermap.org/faq#error401 for more info.