### PR TITLE
Pr fix welcome test malformed url

### DIFF
--- a/welcome/events.py
+++ b/welcome/events.py
@@ -483,9 +483,9 @@ class Events:
                 return
             if guild_settings["GROUPED"]:
                 member = ctx.author
-                members = cast(List[discord.Member], member)
+                members = cast(List[discord.Member], [ctx.author, ctx.me])
             if is_embed and channel.permissions_for(guild.me).embed_links:
-                em = await self.make_embed(member, guild, rand_msg, is_welcome)
+                em = await self.make_embed(members, guild, rand_msg, is_welcome)
                 if await self.config.guild(guild).EMBED_DATA.mention():
                     if guild_settings["GROUPED"]:
                         await channel.send(
@@ -497,7 +497,7 @@ class Events:
                     await channel.send(embed=em, delete_after=60, **sanitize)
             else:
                 await channel.send(
-                    await self.convert_parms(member, guild, rand_msg, is_welcome),
+                    await self.convert_parms(members, guild, rand_msg, is_welcome),
                     delete_after=60,
                     **sanitize,
                 )

--- a/welcome/events.py
+++ b/welcome/events.py
@@ -121,8 +121,8 @@ class Events:
                 url = str(guild.icon.url)
             elif url == "splash":
                 url = str(guild.splash_url)
-            elif url == "avatar" and isinstance(member, discord.Member):
-                url = str(member.display_avatar)
+            elif url == "avatar":
+                url = str(member.display_avatar) if isinstance(member, discord.Member) else ""
             em.set_thumbnail(url=url)
         if EMBED_DATA["image"] or EMBED_DATA["image_goodbye"]:
             url = ""
@@ -134,8 +134,8 @@ class Events:
                 url = str(guild.icon.url)
             elif url == "splash":
                 url = str(guild.splash_url)
-            elif url == "avatar" and isinstance(member, discord.Member):
-                url = str(member.display_avatar)
+            elif url == "avatar":
+                url = str(member.display_avatar) if isinstance(member, discord.Member) else ""
             em.set_image(url=url)
         if EMBED_DATA["icon_url"]:
             url = EMBED_DATA["icon_url"]
@@ -143,8 +143,8 @@ class Events:
                 url = str(guild.icon.url)
             elif url == "splash":
                 url = str(guild.splash_url)
-            elif url == "avatar" and isinstance(member, discord.Member):
-                url = str(member.display_avatar)
+            elif url == "avatar":
+                url = str(member.display_avatar) if isinstance(member, discord.Member) else ""
             em.set_author(name=username, icon_url=url)
         if EMBED_DATA["timestamp"]:
             em.timestamp = datetime.now(timezone.utc)

--- a/welcome/events.py
+++ b/welcome/events.py
@@ -482,13 +482,14 @@ class Events:
             if not channel:
                 return
             if guild_settings["GROUPED"]:
-                member = [ctx.author, ctx.me]
+                member = ctx.author
+                members = cast(List[discord.Member], member)
             if is_embed and channel.permissions_for(guild.me).embed_links:
                 em = await self.make_embed(member, guild, rand_msg, is_welcome)
                 if await self.config.guild(guild).EMBED_DATA.mention():
                     if guild_settings["GROUPED"]:
                         await channel.send(
-                            humanize_list([m.mention for m in member]), embed=em, delete_after=60
+                            humanize_list([m.mention for m in members]), embed=em, delete_after=60
                         )
                     else:
                         await channel.send(member.mention, embed=em, delete_after=60, **sanitize)


### PR DESCRIPTION
Fixes test messages when `grouped` and `embed` are both toggled on. The string `"avatar"` was being set in the thumbnail URL for this corner case, leading to Discord choking on it:

```
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embeds.0.thumbnail.url: Not a well formed URL.
```

~~Just d66ba28a633aa2b495063d225de84fc2427c3718 alone fixes the issue by preventing `make_embed()` from being passed both the author and bot instead of just the author.~~ The other commit is just for code safety.

Found and fixed a couple of problems with my initial commit. Tested with `grouped` and seems OK now.