### PR TITLE
[RoleTools] Fix help strings for select menu options in roletools messages command

### DIFF
--- a/roletools/messages.py
+++ b/roletools/messages.py
@@ -181,7 +181,7 @@ class RoleToolsMessages(RoleToolsMixin):
         """
         Send a select menu to a specified channel for role assignment
 
-        `<channel>` - the channel to send the button select menus to.
+        `<channel>` - the channel to send the select menus to.
         `[menus]...` - The names of the select menus you want included in the
         message up to a maximum of 5.
         `[text]` - The text to be included with the select menu.

--- a/roletools/messages.py
+++ b/roletools/messages.py
@@ -138,7 +138,7 @@ class RoleToolsMessages(RoleToolsMixin):
         """
         Edit a bots message to include Role Buttons
 
-        `<message>` - The existing message to add role buttons to. Must be a bots message.
+        `<message>` - The existing message to add role buttons or select menus to. Must be a bots message.
         `[buttons]...` - The names of the buttons you want to include up to a maximum of 25.
         `[menus]...` - The names of the select menus you want to include up to a maximum of 5.
 
@@ -181,7 +181,7 @@ class RoleToolsMessages(RoleToolsMixin):
         """
         Send a select menu to a specified channel for role assignment
 
-        `<channel>` - the channel to send the button role buttons to.
+        `<channel>` - the channel to send the button select menus to.
         `[menus]...` - The names of the select menus you want included in the
         message up to a maximum of 5.
         `[text]` - The text to be included with the select menu.
@@ -223,9 +223,9 @@ class RoleToolsMessages(RoleToolsMixin):
         menus: commands.Greedy[SelectRoleConverter],
     ) -> None:
         """
-        Edit a bots message to include Role Buttons
+        Edit a bots message to include Select Menus
 
-        `<message>` - The existing message to add role buttons to. Must be a bots message.
+        `<message>` - The existing message to add select menus to. Must be a bots message.
         `[menus]...` - The names of the select menus you want to include up to a maximum of 5.
         """
         if not await self.check_totals(ctx, buttons=0, menus=len(menus)):
@@ -233,7 +233,7 @@ class RoleToolsMessages(RoleToolsMixin):
         if ctx.guild.id not in self.views:
             self.views[ctx.guild.id] = {}
         if message.author.id != ctx.guild.me.id:
-            msg = _("I cannot edit someone elses message to include buttons.")
+            msg = _("I cannot edit someone elses message to include select menus.")
             await ctx.send(msg)
             return
         if not menus:


### PR DESCRIPTION
Fixes strings in `messages.py` under `@roletools_message.command` where buttons are accidentally mentioned instead of menus.

Updates help for commands:
`[p]roletools message edit`
`[p]roletools message editselect`
`[p]roletools message sendselect`