### PR TITLE
[ExtendedModLog] Fix role update audit matching

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -1225,13 +1225,13 @@ class EventMixin:
                             for role in log_before:
                                 if role in before_roles:
                                     entry = log
-                            continue
+                        continue
                     if log.action is discord.AuditLogAction.member_role_update and after_roles:
                         if log_after := getattr(log.after, "roles", []):
                             for role in log_after:
                                 if role in after_roles:
                                     entry = log
-                            continue
+                        continue
                     if target_id == getattr(log.target, "id", None):
                         logger.trace("Found entry through cache")
                         entry = log
@@ -1259,13 +1259,13 @@ class EventMixin:
                             for role in log_before:
                                 if role in before_roles:
                                     entry = log
-                            continue
+                        continue
                     if log.action is discord.AuditLogAction.member_role_update and after_roles:
                         if log_after := getattr(log.after, "roles", []):
                             for role in log_after:
                                 if role in after_roles:
                                     entry = log
-                            continue
+                        continue
                     if target_id == getattr(log.target, "id", None):
                         logger.trace("Found perp through fetch")
                         entry = log


### PR DESCRIPTION
## Summary

Prevent role-filtered member updates from falling through to target-only audit log matching.

This affects both the cached and freshly fetched audit-log paths for role additions and removals.

## Root cause

The existing code already distinguishes removals through `log.before.roles` and additions through `log.after.roles`.

However, each `continue` was inside its corresponding role-list check. When the requested side was empty, the `continue` did not run and execution fell through to the generic member-ID comparison.

For example, while resolving a removal against a newer addition entry, `log.before.roles` is empty. The addition entry could therefore be accepted by the member-ID fallback, causing its reason to appear on the removal log.

Moving each `continue` one indentation level outward ensures a role-filtered lookup finishes evaluating that candidate without falling through, even when the requested side is empty.

No audit-log matching behavior or API assumptions are otherwise changed.

Addresses #356.

## Validation

- Verified additions are not selected for removal lookups.
- Verified removals are not selected for addition lookups.
- Verified matching additions and removals are still selected.
- `py -3.11 -m py_compile extendedmodlog/eventmixin.py`
- `git diff --check`